### PR TITLE
add unambigious license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ maintenance, new features, and keeping the app free.
 
 ## License
 
+[![GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://spdx.org/licenses/GPL-3.0-only.html)
+
 This project is licensed under the **GNU License**.
 You are free to use, modify, and distribute it.
 See the full [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ maintenance, new features, and keeping the app free.
 
 [![GPL-3.0-only](https://img.shields.io/badge/License-GPL--3.0--only-blue.svg)](https://spdx.org/licenses/GPL-3.0-only.html)
 
-This project is licensed under the **GNU License**.
+This project is licensed under the **GNU General Public License v3.0 only (GPL-3.0-only)**.
 You are free to use, modify, and distribute it.
 See the full [LICENSE](LICENSE) file for details.
 


### PR DESCRIPTION
* License: GPL-3.0-only https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/app.pwhs.universalinstaller.yml 
* this badge adds unambigious license badge with spdx license text
* inspiration: 
  * For Clarity's Sake, Please Don't Say "Licensed under GNU GPL 2"! by Richard Stallman https://www.gnu.org/licenses/identify-licenses-clearly.html
  * REUSE makes software licensing as easy as one-two-three https://fsfe.org/news/2024/news-20241114-01.en.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified README License text to explicitly state "GNU General Public License v3.0 only (GPL-3.0-only)".
  * Added a GPL-3.0-only badge in the README License section linking to the license details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->