### PR TITLE
Fix Work Profile installation and Split APK auto-selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 .cxx
 local.properties
 .kotlin
+.gemini/
+docs/github_report_*.md
 
 # Fastlane
 fastlane/report.xml

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/InstallViewModel.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/InstallViewModel.kt
@@ -29,6 +29,7 @@ import app.pwhs.universalinstaller.presentation.install.controller.BaseInstallCo
 import app.pwhs.universalinstaller.presentation.install.controller.DefaultInstallController
 import app.pwhs.universalinstaller.presentation.install.controller.InstallerBackendFactory
 import app.pwhs.universalinstaller.presentation.install.controller.ShizukuInstallController
+import app.pwhs.universalinstaller.presentation.install.controller.ManualInstallController
 import app.pwhs.universalinstaller.presentation.install.controller.RootState
 import androidx.datastore.preferences.core.edit
 import androidx.work.ExistingWorkPolicy
@@ -79,6 +80,7 @@ class InstallViewModel(
 
     private val defaultController = DefaultInstallController(application, packageInstaller, sessionDataRepository, historyDao)
     private val shizukuController = ShizukuInstallController(application, packageInstaller, sessionDataRepository, historyDao)
+    private val manualController = ManualInstallController(application, packageInstaller, sessionDataRepository, historyDao)
 
     // Null on the store flavor — activeController() silently skips the Root branch there.
     private val rootController: BaseInstallController? = backendFactory.createRootController(
@@ -404,6 +406,7 @@ class InstallViewModel(
         _attachedObbFiles.value = emptyList()
 
         viewModelScope.launch {
+            val prefs = try { application.dataStore.data.first() } catch (_: Exception) { null }
             val iconPath = cacheIcon(apkInfo)
             val deleteAfterInstall = readDeleteApkPref()
             val sessionData = SessionData(
@@ -429,25 +432,47 @@ class InstallViewModel(
             // pendingApkInfo has already been cleared, so the callback below only sees these.
             val pkgForTarget = apkInfo?.packageName.orEmpty()
             val nameForTarget = apkInfo?.appName.orEmpty().ifBlank { fn }
-            activeController().install(
-                uris = uris,
-                sessionData = sessionData,
-                scope = viewModelScope,
-                context = application,
-                originalUri = originalUri,
-                deleteAfterInstall = deleteAfterInstall,
-                onSuccess = onSuccess,
-                onSessionCreated = if (trackDialogTarget) {
-                    { realSessionId ->
-                        _dialogTarget.value = DialogTarget(
-                            sessionId = realSessionId,
-                            packageName = pkgForTarget,
-                            appName = nameForTarget,
-                            iconPath = iconPath,
-                        )
-                    }
-                } else null,
-            )
+            val controller = activeController()
+            val targetedUserId = prefs?.get(PreferencesKeys.INSTALL_USER_ID)
+            
+            if (controller is ManualInstallController && targetedUserId != null) {
+                controller.installTargeted(
+                    uris = uris,
+                    sessionData = sessionData,
+                    userId = targetedUserId,
+                    scope = viewModelScope,
+                    onSessionCreated = if (trackDialogTarget) {
+                        { realSessionId: UUID ->
+                            _dialogTarget.value = DialogTarget(
+                                sessionId = realSessionId,
+                                packageName = pkgForTarget,
+                                appName = nameForTarget,
+                                iconPath = iconPath,
+                            )
+                        }
+                    } else null
+                )
+            } else {
+                controller.install(
+                    uris = uris,
+                    sessionData = sessionData,
+                    scope = viewModelScope,
+                    context = application,
+                    originalUri = originalUri,
+                    deleteAfterInstall = deleteAfterInstall,
+                    onSuccess = onSuccess,
+                    onSessionCreated = if (trackDialogTarget) {
+                        { realSessionId: UUID ->
+                            _dialogTarget.value = DialogTarget(
+                                sessionId = realSessionId,
+                                packageName = pkgForTarget,
+                                appName = nameForTarget,
+                                iconPath = iconPath,
+                            )
+                        }
+                    } else null,
+                )
+            }
         }
     }
 
@@ -1321,7 +1346,11 @@ class InstallViewModel(
         val spoofRoot = prefs?.get(PreferencesKeys.ROOT_SET_INSTALL_SOURCE) ?: false
         val targetedUser = prefs?.get<Int>(PreferencesKeys.INSTALL_USER_ID) != null
 
-        if ((useRoot || spoofRoot || targetedUser) && rootController != null) {
+        if (targetedUser) {
+            return manualController
+        }
+
+        if ((useRoot || spoofRoot) && rootController != null) {
             // Verify root is still granted. If it's UNKNOWN (no shell yet) or was 
             // previously DENIED, try an active request. This ensures the install 
             // actually uses the root controller if possible.
@@ -1784,7 +1813,7 @@ class InstallViewModel(
         val libsBest = entries
             .filter { it.type == SplitType.Libs }
             .minByOrNull { abiPriority[it.name.lowercase()] ?: Int.MAX_VALUE }
-            ?.uri
+            ?.name
 
         // Density: closest dpi to the device's actual densityDpi. Names parse as "${dpi}dpi".
         val deviceDpi = context.resources.displayMetrics.densityDpi
@@ -1794,7 +1823,7 @@ class InstallViewModel(
                 val dpi = it.name.removeSuffix("dpi").toIntOrNull() ?: Int.MAX_VALUE
                 kotlin.math.abs(dpi - deviceDpi)
             }
-            ?.uri
+            ?.name
 
         // Locale: include splits whose displayed language matches any of the user's preferred
         // locales. We match against the top-priority locale's display language (English form
@@ -1811,8 +1840,8 @@ class InstallViewModel(
             val e = entries[i]
             val keep = when (e.type) {
                 SplitType.Base, SplitType.Feature, SplitType.Other -> true
-                SplitType.Libs -> e.uri == libsBest
-                SplitType.ScreenDensity -> e.uri == densityBest
+                SplitType.Libs -> e.name.equals(libsBest, ignoreCase = true)
+                SplitType.ScreenDensity -> e.name.equals(densityBest, ignoreCase = true)
                 SplitType.Locale -> e.name.lowercase() in userLangs
             }
             if (e.selected != keep) entries[i] = e.copy(selected = keep)

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/BaseInstallController.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/BaseInstallController.kt
@@ -169,7 +169,7 @@ abstract class BaseInstallController(
         }
     }
 
-    private suspend fun saveHistory(
+    protected suspend fun saveHistory(
         sessionData: SessionData?,
         success: Boolean,
         errorMessage: String? = null,

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualInstallController.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualInstallController.kt
@@ -3,19 +3,27 @@ package app.pwhs.universalinstaller.presentation.install.controller
 import android.app.Application
 import android.net.Uri
 import app.pwhs.universalinstaller.data.local.InstallHistoryDao
+import app.pwhs.universalinstaller.domain.model.SessionData
 import app.pwhs.universalinstaller.domain.repository.SessionDataRepository
-import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
-import app.pwhs.universalinstaller.presentation.setting.dataStore
+import app.pwhs.universalinstaller.presentation.install.InstallErrorHelper
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import ru.solrudev.ackpine.installer.InstallFailure
 import ru.solrudev.ackpine.installer.PackageInstaller
+import ru.solrudev.ackpine.resources.ResolvableString
+import ru.solrudev.ackpine.session.Progress
 import ru.solrudev.ackpine.session.ProgressSession
+import ru.solrudev.ackpine.session.Session
+import timber.log.Timber
 import java.util.UUID
 
 /**
- * A controller that handles targeted user installs manually.
+ * A controller that handles targeted user installs manually using hidden APIs.
+ * This bypasses Ackpine's standard flow to support specific User IDs (e.g. Work Profiles).
  */
 class ManualInstallController(
     private val application: Application,
@@ -29,19 +37,50 @@ class ManualInstallController(
         name: String,
         packageName: String,
     ): ProgressSession<InstallFailure> {
-        // This won't be called if we override install()
-        throw UnsupportedOperationException("Use install() with userId")
+        // This is not used as we override the main install() method.
+        throw UnsupportedOperationException("ManualInstallController uses targetedInstall instead")
     }
 
     fun installTargeted(
         uris: List<Uri>,
-        name: String,
+        sessionData: SessionData,
         userId: Int,
         scope: CoroutineScope,
+        onSessionCreated: ((UUID) -> Unit)? = null,
     ) {
-        // We'll simulate a session ID to keep the UI happy
         val sessionId = UUID.randomUUID()
-        // ... implementation that uses ManualTargetedInstaller ...
-        // and updates sessionDataRepository
+        val data = sessionData.copy(id = sessionId)
+        
+        scope.launch {
+            sessionDataRepository.addSessionData(data)
+            onSessionCreated?.invoke(sessionId)
+            
+            val result = ManualTargetedInstaller.install(
+                context = application,
+                uris = uris,
+                userId = userId,
+                onProgress = { progressValue ->
+                    // Progress is 0.0 to 1.0
+                    val progress = Progress((progressValue * 100).toInt(), 100)
+                    sessionDataRepository.updateSessionProgress(sessionId, progress)
+                }
+            )
+
+            result.fold(
+                onSuccess = {
+                    sessionDataRepository.updateSessionProgress(sessionId, Progress(100, 100))
+                    // Wait a bit to show 100%
+                    kotlinx.coroutines.delay(500)
+                    saveHistory(data, success = true)
+                    sessionDataRepository.removeSessionData(sessionId)
+                },
+                onFailure = { e ->
+                    Timber.e(e, "Manual targeted install failed")
+                    val errorMsg = ResolvableString.raw(e.message ?: "Installation failed")
+                    saveHistory(data, success = false, errorMessage = e.message)
+                    sessionDataRepository.setError(sessionId, errorMsg)
+                }
+            )
+        }
     }
 }

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualInstallController.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualInstallController.kt
@@ -5,19 +5,13 @@ import android.net.Uri
 import app.pwhs.universalinstaller.data.local.InstallHistoryDao
 import app.pwhs.universalinstaller.domain.model.SessionData
 import app.pwhs.universalinstaller.domain.repository.SessionDataRepository
-import app.pwhs.universalinstaller.presentation.install.InstallErrorHelper
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import ru.solrudev.ackpine.installer.InstallFailure
 import ru.solrudev.ackpine.installer.PackageInstaller
 import ru.solrudev.ackpine.resources.ResolvableString
 import ru.solrudev.ackpine.session.Progress
 import ru.solrudev.ackpine.session.ProgressSession
-import ru.solrudev.ackpine.session.Session
 import timber.log.Timber
 import java.util.UUID
 

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualTargetedInstaller.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ManualTargetedInstaller.kt
@@ -1,9 +1,14 @@
 package app.pwhs.universalinstaller.presentation.install.controller
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageInstaller
 import android.net.Uri
+import android.os.Build
 import app.pwhs.universalinstaller.util.HiddenApiHacks
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -28,31 +33,59 @@ object ManualTargetedInstaller {
                 PackageInstaller.SessionParams.MODE_FULL_INSTALL
             )
             
-            // Allow downgrade, test packages etc. could be added here if needed
-            
             val sessionId = targetedInstaller.createSession(params)
-            targetedInstaller.openSession(sessionId).use { session ->
-                uris.forEachIndexed { index, uri ->
-                    val name = "apk_$index.apk"
-                    val pfd = context.contentResolver.openFileDescriptor(uri, "r")
-                        ?: throw RuntimeException("Failed to open Uri: $uri")
-                    pfd.use {
-                        session.openWrite(name, 0, it.statSize).use { out ->
-                            java.io.FileInputStream(it.fileDescriptor).use { input ->
-                                input.copyTo(out)
+            val action = "app.pwhs.universalinstaller.INSTALL_STATUS_$sessionId"
+            val resultDeferred = CompletableDeferred<Result<Unit>>()
+            
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context, intent: Intent) {
+                    val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)
+                    if (status == PackageInstaller.STATUS_SUCCESS) {
+                        resultDeferred.complete(Result.success(Unit))
+                    } else {
+                        val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                        resultDeferred.complete(Result.failure(RuntimeException(message ?: "Installation failed (status $status)")))
+                    }
+                    ctx.unregisterReceiver(this)
+                }
+            }
+            
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(receiver, IntentFilter(action))
+            }
+
+            try {
+                targetedInstaller.openSession(sessionId).use { session ->
+                    uris.forEachIndexed { index, uri ->
+                        val name = "apk_$index.apk"
+                        val pfd = context.contentResolver.openFileDescriptor(uri, "r")
+                            ?: throw RuntimeException("Failed to open Uri: $uri")
+                        pfd.use {
+                            session.openWrite(name, 0, it.statSize).use { out ->
+                                java.io.FileInputStream(it.fileDescriptor).use { input ->
+                                    input.copyTo(out)
+                                }
                             }
                         }
+                        onProgress((index + 1).toFloat() / uris.size)
                     }
-                    onProgress((index + 1).toFloat() / uris.size)
+                    
+                    val intent = Intent(action)
+                    intent.setPackage(context.packageName)
+                    val pendingIntent = android.app.PendingIntent.getBroadcast(
+                        context, sessionId, intent,
+                        android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_MUTABLE
+                    )
+                    session.commit(pendingIntent.intentSender)
                 }
-                
-                // Track result via broadcast
-                val intent = android.content.Intent("app.pwhs.universalinstaller.INSTALL_STATUS")
-                val receiver = android.app.PendingIntent.getBroadcast(
-                    context, sessionId, intent,
-                    android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_MUTABLE
-                )
-                session.commit(receiver.intentSender)
+                resultDeferred.await().getOrThrow()
+            } catch (e: Exception) {
+                try {
+                    context.unregisterReceiver(receiver)
+                } catch (_: Exception) {}
+                throw e
             }
         }
     }


### PR DESCRIPTION
This PR addresses several issues:
1. Fixes Work Profile installation by implementing a targeted ManualInstallController (#40, #27).
2. Improves Split APK auto-selection logic to handle multiple splits for the same architecture (#37).

Fixes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to ignore new local and generated files.

* **Refactor**
  * Improved manual/targeted install flow with per-session tracking, persistent session state, and more reliable progress reporting.
  * Installer now awaits and reports real install results and handles device/OS receiver requirements.

* **Bug Fixes**
  * More robust error handling and history recording for manual installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->