### PR TITLE
fix(install): default replaceExisting to true so Shizuku/Root upgrades do not fail with package conflict

### DIFF
--- a/app/src/full/java/app/pwhs/universalinstaller/presentation/install/controller/RootInstallController.kt
+++ b/app/src/full/java/app/pwhs/universalinstaller/presentation/install/controller/RootInstallController.kt
@@ -45,7 +45,10 @@ class RootInstallController(
             libsu {
                 bypassLowTargetSdkBlock = prefs[PreferencesKeys.ROOT_BYPASS_LOW_TARGET_SDK] ?: false
                 allowTest = prefs[PreferencesKeys.ROOT_ALLOW_TEST] ?: false
-                replaceExisting = prefs[PreferencesKeys.ROOT_REPLACE_EXISTING] ?: false
+                // Default ON to match the UI (`?: true` in Settings/dialog). ackpine only sets
+                // INSTALL_REPLACE_EXISTING when true; false makes an upgrade of an existing package
+                // fail with INSTALL_FAILED_ALREADY_EXISTS. Explicit user choice still honored.
+                replaceExisting = prefs[PreferencesKeys.ROOT_REPLACE_EXISTING] ?: true
                 requestDowngrade = prefs[PreferencesKeys.ROOT_REQUEST_DOWNGRADE] ?: false
                 grantAllRequestedPermissions = prefs[PreferencesKeys.ROOT_GRANT_ALL_PERMISSIONS] ?: false
                 allUsers = prefs[PreferencesKeys.ROOT_ALL_USERS] ?: false

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ShizukuInstallController.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/ShizukuInstallController.kt
@@ -37,7 +37,12 @@ class ShizukuInstallController(
             shizuku {
                 bypassLowTargetSdkBlock = prefs[PreferencesKeys.SHIZUKU_BYPASS_LOW_TARGET_SDK] ?: false
                 allowTest = prefs[PreferencesKeys.SHIZUKU_ALLOW_TEST] ?: false
-                replaceExisting = prefs[PreferencesKeys.SHIZUKU_REPLACE_EXISTING] ?: false
+                // Default ON to match the UI (Settings/dialog show this as `?: true`). ackpine only
+                // ORs INSTALL_REPLACE_EXISTING into the session when this is true; with it false a
+                // privileged upgrade of an existing package fails with INSTALL_FAILED_ALREADY_EXISTS
+                // (the "package conflict" error). An explicit user choice is still honored — `?:`
+                // only fills the never-set case.
+                replaceExisting = prefs[PreferencesKeys.SHIZUKU_REPLACE_EXISTING] ?: true
                 requestDowngrade = prefs[PreferencesKeys.SHIZUKU_REQUEST_DOWNGRADE] ?: false
                 grantAllRequestedPermissions = prefs[PreferencesKeys.SHIZUKU_GRANT_ALL_PERMISSIONS] ?: false
                 allUsers = prefs[PreferencesKeys.SHIZUKU_ALL_USERS] ?: false


### PR DESCRIPTION
## Summary

Upgrading an already-installed app through the **Shizuku** or **Root** backend fails with
`INSTALL_FAILED_ALREADY_EXISTS` — the "package conflict" error — even when "Replace existing"
appears to be enabled in Settings. This is the root cause behind #11 ("replace existing never works").

## Root cause

The option's default is inconsistent between the UI and the install controllers:

- `SettingViewModel` (the Settings screen state) and `DialogMenuContent` (the install dialog) both
  read it as `?: true`, so the switch **shows as ON** by default.
- `ShizukuInstallController` and `RootInstallController` read the same preference as `?: false`.

So a user who never explicitly toggles the (already-on-looking) switch installs with replace **off**.
ackpine's `PackageInstallerProxy.applyInstallFlags` only ORs `INSTALL_REPLACE_EXISTING` into the
privileged session's `installFlags` when `replaceExisting` is `true`; without it, committing a session
for a package that already exists is rejected as a conflict. (Non-privileged/default installs replace by
default, which is why only the Shizuku/Root paths are affected.)

## Fix

Align the two controller defaults with the UI (`?: true`). An explicit user **off** is still honored,
because `?:` only fills the never-set case.

```kotlin
// ShizukuInstallController / RootInstallController
replaceExisting = prefs[PreferencesKeys.SHIZUKU_REPLACE_EXISTING] ?: true   // was ?: false
```

## Test plan

1. Enable **Use Shizuku**, grant Shizuku permission, leave "Replace existing" at its default.
2. Install an app, then install a newer build of the same package (same signing key) via Shizuku.
   - **Before:** fails with "Package conflict" / `INSTALL_FAILED_ALREADY_EXISTS`.
   - **After:** upgrades in place successfully.
3. Explicitly turn "Replace existing" **off** and confirm a conflicting install is still rejected
   (the explicit choice is respected).

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation now defaults to replacing existing app versions instead of causing failures during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->