### PR TITLE
Add progress dialog for APK extraction

### DIFF
--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/manage/ManageScreen.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/manage/ManageScreen.kt
@@ -381,6 +381,36 @@ private fun UninstallUi(
         )
     }
 
+    if (uiState.extractState is ExtractState.Running) {
+        val runningState = uiState.extractState
+        AlertDialog(
+            onDismissRequest = { /* Cannot dismiss, it's running */ },
+            title = { Text(stringResource(R.string.extract_progress_title, runningState.appName)) },
+            text = {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    if (runningState.totalBytes > 0) {
+                        val progress = runningState.bytesCopied.toFloat() / runningState.totalBytes.toFloat()
+                        androidx.compose.material3.LinearProgressIndicator(
+                            progress = { progress },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "${android.text.format.Formatter.formatShortFileSize(context, runningState.bytesCopied)} / ${android.text.format.Formatter.formatShortFileSize(context, runningState.totalBytes)}",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    } else {
+                        androidx.compose.material3.LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    }
+                }
+            },
+            confirmButton = {}
+        )
+    }
+
     // Privileged-action snackbar (Force stop / Disable / Enable). Lives alongside the
     // extract snackbar — both share the same SnackbarHostState; the system Material
     // queue handles back-to-back messages.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="extract_done_action_open">Open folder</string>
     <string name="extract_failed">Extract failed: %1$s</string>
     <string name="extract_action_backups">Backups</string>
+1    <string name="extract_progress_title">Extracting %1$s…</string>
     <string name="manage_action_open_app">Open app</string>
     <string name="manage_action_open_app_sub">Launch %1$s</string>
     <string name="manage_action_app_info">App info</string>


### PR DESCRIPTION
This PR implements a progress popup dialog during APK extraction as requested in #62 to provide better visual feedback to users while the extraction is running. Closes #62.

Fixes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added extraction progress dialog displaying real-time byte copy progress and total size information
  * Progress indicator automatically adjusts between determinate (with size data) and indeterminate display modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->