### PR TITLE
Fix incorrect Root indication on non-rooted phones

### DIFF
--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/BackendSelfHeal.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/BackendSelfHeal.kt
@@ -45,7 +45,7 @@ object BackendSelfHeal {
                 Timber.w(t, "BackendSelfHeal: root probe threw")
                 RootState.UNAVAILABLE
             }
-            if (state == RootState.UNAVAILABLE || state == RootState.NOT_ROOTED) {
+            if (state == RootState.UNAVAILABLE || state == RootState.NOT_ROOTED || state == RootState.DENIED) {
                 Timber.i("BackendSelfHeal: USE_ROOT on but root definitively unavailable ($state) — disabling pref")
                 runCatching {
                     application.dataStore.edit { it[PreferencesKeys.USE_ROOT] = false }

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/FullInstallerBackendFactory.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/FullInstallerBackendFactory.kt
@@ -39,6 +39,23 @@ class FullInstallerBackendFactory : InstallerBackendFactory {
      *   - false → DENIED (manager said no)
      */
     override suspend fun probeRootState(): RootState = withContext(Dispatchers.IO) {
+        val suPaths = arrayOf(
+            "/system/app/Superuser.apk",
+            "/sbin/su",
+            "/system/bin/su",
+            "/system/xbin/su",
+            "/data/local/xbin/su",
+            "/data/local/bin/su",
+            "/system/sd/xbin/su",
+            "/system/bin/failsafe/su",
+            "/data/local/su",
+            "/su/bin/su"
+        )
+        val hasSu = suPaths.any { java.io.File(it).exists() }
+        if (!hasSu) {
+            return@withContext RootState.NOT_ROOTED
+        }
+
         try {
             when (Shell.isAppGrantedRoot()) {
                 null -> RootState.UNKNOWN

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingViewModel.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingViewModel.kt
@@ -345,9 +345,13 @@ class SettingViewModel(
                 setUseShizuku(true)
             }
             InstallMode.ROOT -> viewModelScope.launch {
-                dataStore.edit { p ->
-                    p[PreferencesKeys.USE_SHIZUKU] = false
-                    p[PreferencesKeys.USE_ROOT] = true
+                val state = backendFactory.requestRoot()
+                _rootState.value = state
+                if (state == RootState.READY) {
+                    dataStore.edit { p ->
+                        p[PreferencesKeys.USE_SHIZUKU] = false
+                        p[PreferencesKeys.USE_ROOT] = true
+                    }
                 }
             }
         }
@@ -394,7 +398,15 @@ class SettingViewModel(
 
     fun setUseRoot(enabled: Boolean) {
         viewModelScope.launch {
-            dataStore.edit { prefs -> prefs[PreferencesKeys.USE_ROOT] = enabled }
+            if (enabled) {
+                val state = backendFactory.requestRoot()
+                _rootState.value = state
+                if (state == RootState.READY) {
+                    dataStore.edit { prefs -> prefs[PreferencesKeys.USE_ROOT] = true }
+                }
+            } else {
+                dataStore.edit { prefs -> prefs[PreferencesKeys.USE_ROOT] = false }
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes issue #57 by adding a proper su binary filesystem check during the root probe, preventing non-rooted devices from defaulting to a RootState.UNKNOWN that allows the UI to incorrectly enable and display 'Using Root'. It also ensures USE_ROOT preference cannot be blindly enabled without verifying the root state first, and BackendSelfHeal reliably disables the setting if root is DENIED or NOT_ROOTED. Closes #57.

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved detection and handling of root access denial scenarios
* Root settings now validate actual root availability before persisting user configuration preferences
* Enhanced root access detection efficiency through optimized checking procedures
* Fixed potential configuration issues where root could be enabled without proper system validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->