### PR TITLE
Fix root mode default installer

### DIFF
--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/FullInstallerBackendFactory.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/FullInstallerBackendFactory.kt
@@ -264,10 +264,12 @@ class FullInstallerBackendFactory : InstallerBackendFactory {
                     cont.invokeOnCancellation {
                         runCatching { RootService.unbind(connection) }
                     }
-                    try {
-                        RootService.bind(intent, connection)
-                    } catch (t: Throwable) {
-                        if (cont.isActive) cont.resumeWithException(t)
+                    android.os.Handler(android.os.Looper.getMainLooper()).post {
+                        try {
+                            RootService.bind(intent, connection)
+                        } catch (t: Throwable) {
+                            if (cont.isActive) cont.resumeWithException(t)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/app/pwhs/universalinstaller/privileged/PrivilegedRootService.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/privileged/PrivilegedRootService.kt
@@ -20,7 +20,9 @@ class PrivilegedRootService : RootService() {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
             org.lsposed.hiddenapibypass.HiddenApiBypass.addHiddenApiExemptions(
                 "Landroid/content/pm/IPackageManager",
-                "Landroid/os/ServiceManager"
+                "Landroid/os/ServiceManager",
+                "Landroid/content/pm/ParceledListSlice",
+                "Landroid/content/pm/BaseParceledListSlice"
             )
         }
         return ServiceBinder() as IBinder

--- a/app/src/main/java/app/pwhs/universalinstaller/privileged/PrivilegedRootService.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/privileged/PrivilegedRootService.kt
@@ -16,8 +16,16 @@ import com.topjohnwu.superuser.ipc.RootService
  */
 class PrivilegedRootService : RootService() {
 
-    override fun onBind(intent: Intent): IBinder = ServiceBinder() as IBinder
-
+    override fun onBind(intent: Intent): IBinder {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            org.lsposed.hiddenapibypass.HiddenApiBypass.addHiddenApiExemptions(
+                "Landroid/content/pm/IPackageManager",
+                "Landroid/os/ServiceManager"
+            )
+        }
+        return ServiceBinder() as IBinder
+    }
+    
     private class ServiceBinder : IPrivilegedService.Stub() {
         override fun setDefaultInstaller(component: ComponentName, lock: Boolean) {
             // ServiceManager.getService runs in this root process so the returned binder is

--- a/app/src/main/java/app/pwhs/universalinstaller/util/ShizukuDefaultInstaller.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/util/ShizukuDefaultInstaller.kt
@@ -25,7 +25,9 @@ object ShizukuDefaultInstaller {
             runCatching {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     HiddenApiBypass.addHiddenApiExemptions(
-                        "Landroid/content/pm/IPackageManager"
+                        "Landroid/content/pm/IPackageManager",
+                        "Landroid/content/pm/ParceledListSlice",
+                        "Landroid/content/pm/BaseParceledListSlice"
                     )
                 }
                 val packageBinder = SystemServiceHelper.getSystemService("package")

--- a/app/src/main/java/app/pwhs/universalinstaller/util/ShizukuDefaultInstaller.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/util/ShizukuDefaultInstaller.kt
@@ -25,7 +25,7 @@ object ShizukuDefaultInstaller {
             runCatching {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     HiddenApiBypass.addHiddenApiExemptions(
-                        "Landroid/content/pm/IPackageManager;",
+                        "Landroid/content/pm/IPackageManager"
                     )
                 }
                 val packageBinder = SystemServiceHelper.getSystemService("package")


### PR DESCRIPTION
This PR fixes #85 by ensuring `RootService.bind()` is called on the main thread and adding `HiddenApiBypass` for `IPackageManager` and `ServiceManager` in the root process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting the installer by adjusting how the privileged service connection is established, reducing chances of crashes or failed connections on some devices.
  * Enhanced Android P+ compatibility for privileged operations, improving consistency when setting the default installer and initializing required service access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->