### PR TITLE
Fix filename sanitization to allow parentheses

### DIFF
--- a/core/src/main/java/app/pwhs/core/install/ApkExtractor.kt
+++ b/core/src/main/java/app/pwhs/core/install/ApkExtractor.kt
@@ -323,7 +323,7 @@ object ApkExtractor {
         val cleaned = name.map { c ->
             when {
                 c.isLetterOrDigit() -> c
-                c == ' ' || c == '-' || c == '_' || c == '.' -> c
+                c == ' ' || c == '-' || c == '_' || c == '.' || c == '(' || c == ')' -> c
                 else -> '_'
             }
         }.joinToString("").trim().ifBlank { "app" }


### PR DESCRIPTION
This PR fixes #86 by updating the filename sanitization logic to preserve parentheses, which are commonly found in app names like `Google Play services (19.8.31)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * APK file names now keep parentheses `(` and `)` instead of converting them to underscores during extraction.
  * Other filename cleanup rules remain unchanged, including character filtering, trimming, default naming, and length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->