### PR TITLE
Fix visibility of background service apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,13 +50,8 @@
         android:name="android.permission.ENFORCE_UPDATE_OWNERSHIP"
         tools:node="remove" />
 
-    <!-- Query all installed packages on Android 11+ without QUERY_ALL_PACKAGES -->
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent>
-    </queries>
+    <!-- Require QUERY_ALL_PACKAGES to see background services without launcher intents -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application
         android:name=".App"

--- a/core/src/main/java/app/pwhs/core/install/ApkExtractor.kt
+++ b/core/src/main/java/app/pwhs/core/install/ApkExtractor.kt
@@ -323,7 +323,7 @@ object ApkExtractor {
         val cleaned = name.map { c ->
             when {
                 c.isLetterOrDigit() -> c
-                c == ' ' || c == '-' || c == '_' || c == '.' -> c
+                c == ' ' || c == '-' || c == '_' || c == '.' || c == '(' || c == ')' -> c
                 else -> '_'
             }
         }.joinToString("").trim().ifBlank { "app" }


### PR DESCRIPTION
This PR fixes #84 by replacing the restricted `<queries>` block with the `QUERY_ALL_PACKAGES` permission in `AndroidManifest.xml`. This ensures that apps without a launcher intent (such as Every Proxy Network Bridge) are correctly listed in the Manage and Backup screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broadened app visibility on Android to improve discovery of installed apps.
  * File names generated by the app now preserve parentheses, making extracted names closer to the originals.

* **Bug Fixes**
  * Updated package lookup behavior on newer Android versions for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->