### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,4 +296,4 @@ See the full [LICENSE](LICENSE) file for details.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=pass-with-high-score/universal-installer&type=Date)](https://www.star-history.com/#pass-with-high-score/universal-installer&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=pass-with-high-score/universal-installer&type=Date)](https://star-history.dera.page/#pass-with-high-score/universal-installer&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README currently fails to render because of GitHub stargazer API restrictions on the upstream service. This switches the chart to star-history.dera.page, which uses another data source that requires no API token and serves both the API and frontend from a single domain. The chart works again with no change in appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link and image source to use the new website domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->