### PR TITLE
feat(tv): add Shizuku installation support

### DIFF
--- a/core/src/main/java/app/pwhs/core/data/local/SharedDataStore.kt
+++ b/core/src/main/java/app/pwhs/core/data/local/SharedDataStore.kt
@@ -14,6 +14,16 @@ object SharedPrefsKeys {
 
     /** TV: when true (default) and root is available, install silently via the root shell. */
     val ROOT_SILENT_INSTALL = booleanPreferencesKey("tv_root_silent_install")
+    val TV_SHIZUKU_REPLACE = booleanPreferencesKey("tv_shizuku_replace")
+    val TV_ROOT_REPLACE = booleanPreferencesKey("tv_root_replace")
+    val TV_SHIZUKU_DOWNGRADE = booleanPreferencesKey("tv_shizuku_downgrade")
+    val TV_ROOT_DOWNGRADE = booleanPreferencesKey("tv_root_downgrade")
+    val TV_SHIZUKU_GRANT = booleanPreferencesKey("tv_shizuku_grant")
+    val TV_ROOT_GRANT = booleanPreferencesKey("tv_root_grant")
+    val TV_SHIZUKU_TEST = booleanPreferencesKey("tv_shizuku_test")
+    val TV_ROOT_TEST = booleanPreferencesKey("tv_root_test")
+    val TV_SHIZUKU_ALL_USERS = booleanPreferencesKey("tv_shizuku_all_users")
+    val TV_ROOT_ALL_USERS = booleanPreferencesKey("tv_root_all_users")
 
     /**
      * "Normal" or "Strict". Declared here because onboarding lives in :core but the setting is

--- a/core/src/main/java/app/pwhs/core/install/RootInstaller.kt
+++ b/core/src/main/java/app/pwhs/core/install/RootInstaller.kt
@@ -3,8 +3,11 @@ package app.pwhs.core.install
 import android.content.Context
 import android.net.Uri
 import app.pwhs.core.util.RootShell
+import app.pwhs.core.data.local.SharedPrefsKeys
+import app.pwhs.core.data.local.dataStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.first
 import ru.solrudev.ackpine.splits.Apk
 import ru.solrudev.ackpine.splits.ApkSplits.validate
 import ru.solrudev.ackpine.splits.CloseableSequence
@@ -44,10 +47,16 @@ class RootInstaller(private val context: Context) {
     ): ApkInstaller.Result = withContext(Dispatchers.IO) {
         val stagingDir = File(context.cacheDir, "root_install_${UUID.randomUUID()}").apply { mkdirs() }
         try {
+            val prefs = context.dataStore.data.first()
+            val replace = prefs[SharedPrefsKeys.TV_ROOT_REPLACE] ?: true
+            val downgrade = prefs[SharedPrefsKeys.TV_ROOT_DOWNGRADE] ?: false
+            val grant = prefs[SharedPrefsKeys.TV_ROOT_GRANT] ?: false
+            val test = prefs[SharedPrefsKeys.TV_ROOT_TEST] ?: false
+            val allUsers = prefs[SharedPrefsKeys.TV_ROOT_ALL_USERS] ?: false
             val splits = stage(uri, isBundle, stagingDir, onProgress)
             require(splits.isNotEmpty()) { "No APK found to install" }
 
-            val sessionId = createSession()
+            val sessionId = createSession(replace, downgrade, grant, test, allUsers)
             splits.forEachIndexed { idx, file ->
                 writeSplit(sessionId, idx, file)
                 onProgress(0.8f + 0.15f * ((idx + 1f) / splits.size))
@@ -142,8 +151,15 @@ class RootInstaller(private val context: Context) {
     private fun openInput(uri: Uri) =
         context.contentResolver.openInputStream(uri) ?: throw IllegalStateException("Cannot open $uri")
 
-    private suspend fun createSession(): String {
-        val r = RootShell.exec("pm install-create -r")
+    private suspend fun createSession(replace: Boolean, downgrade: Boolean, grant: Boolean, test: Boolean, allUsers: Boolean): String {
+        val flags = buildString {
+            if (replace) append(" -r")
+            if (downgrade) append(" -d")
+            if (grant) append(" -g")
+            if (test) append(" -t")
+            if (allUsers) append(" --user 0")
+        }
+        val r = RootShell.exec("pm install-create$flags")
         if (!r.isSuccess) throw RuntimeException("pm install-create failed: ${r.output.trim()}")
         return SESSION_ID.find(r.output)?.groupValues?.get(1)
             ?: throw RuntimeException("Could not parse session id from: ${r.output.trim()}")

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -99,6 +99,9 @@ kotlin {
 
 dependencies {
     implementation(project(":core"))
+    implementation(libs.shizuku.api)
+    implementation(libs.shizuku.provider)
+    testImplementation(libs.junit)
     // Installs the packaged profile at first run on API 28-30, where the platform does not do
     // it itself. Already on the classpath transitively; declared so the dependency is explicit.
     implementation(libs.androidx.profileinstaller)

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -39,6 +39,14 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.UniversalInstaller">
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:enabled="true"
+            android:exported="true"
+            android:multiprocess="false"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
         <!-- singleTop so "Open with" on an already-running app delivers to onNewIntent
              instead of stacking a second copy of the whole TV UI. -->
         <activity

--- a/tv/src/main/java/app/pwhs/tv/install/ShizukuInstaller.kt
+++ b/tv/src/main/java/app/pwhs/tv/install/ShizukuInstaller.kt
@@ -1,0 +1,67 @@
+package app.pwhs.tv.install
+
+import android.content.Context
+import android.net.Uri
+import app.pwhs.core.install.ApkInstaller
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import ru.solrudev.ackpine.DelicateAckpineApi
+import ru.solrudev.ackpine.installer.PackageInstaller
+import ru.solrudev.ackpine.installer.createSession
+import ru.solrudev.ackpine.session.Session
+import ru.solrudev.ackpine.session.progress
+import ru.solrudev.ackpine.session.await
+import ru.solrudev.ackpine.session.parameters.Confirmation
+import ru.solrudev.ackpine.shizuku.shizuku
+import ru.solrudev.ackpine.splits.ApkSplits.validate
+import ru.solrudev.ackpine.splits.CloseableSequence
+import ru.solrudev.ackpine.splits.SplitPackage.Companion.toSplitPackage
+import ru.solrudev.ackpine.splits.ZippedApkSplits
+import ru.solrudev.ackpine.splits.get
+
+/** Uses the same privileged Ackpine backend as the phone app. */
+class ShizukuInstaller(private val context: Context) {
+    @OptIn(DelicateAckpineApi::class)
+    suspend fun install(uri: Uri, isBundle: Boolean, onProgress: (Float) -> Unit): ApkInstaller.Result =
+        coroutineScope {
+            try {
+                val uris = if (isBundle) compatibleSplits(uri) else listOf(uri)
+                require(uris.isNotEmpty()) { "No APK found in bundle" }
+                val session = PackageInstaller.getInstance(context).createSession(uris) {
+                    confirmation = Confirmation.IMMEDIATE
+                    shizuku { replaceExisting = true }
+                }
+                val progressJob = launch {
+                    session.progress.collect {
+                        if (it.max > 0) onProgress((it.progress.toFloat() / it.max).coerceIn(0f, 1f))
+                    }
+                }
+                try {
+                    when (val result = session.await()) {
+                        Session.State.Succeeded -> ApkInstaller.Result.Success
+                        is Session.State.Failed -> ApkInstaller.Result.Failure(result.failure.toString())
+                    }
+                } catch (e: CancellationException) {
+                    session.cancel()
+                    throw e
+                } finally {
+                    progressJob.cancel()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                ApkInstaller.Result.Failure(e.message ?: e.javaClass.simpleName)
+            }
+        }
+
+    private suspend fun compatibleSplits(uri: Uri): List<Uri> {
+        val sequence = ZippedApkSplits.getApksForUri(uri, context)
+            .validate().toSplitPackage().filterCompatible(context).get()
+        return try {
+            sequence.toList().map { it.apk.uri }.toList()
+        } finally {
+            (sequence as? CloseableSequence<*>)?.close()
+        }
+    }
+}

--- a/tv/src/main/java/app/pwhs/tv/install/ShizukuInstaller.kt
+++ b/tv/src/main/java/app/pwhs/tv/install/ShizukuInstaller.kt
@@ -3,9 +3,12 @@ package app.pwhs.tv.install
 import android.content.Context
 import android.net.Uri
 import app.pwhs.core.install.ApkInstaller
+import app.pwhs.core.data.local.SharedPrefsKeys
+import app.pwhs.core.data.local.dataStore
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
 import ru.solrudev.ackpine.DelicateAckpineApi
 import ru.solrudev.ackpine.installer.PackageInstaller
 import ru.solrudev.ackpine.installer.createSession
@@ -26,11 +29,18 @@ class ShizukuInstaller(private val context: Context) {
     suspend fun install(uri: Uri, isBundle: Boolean, onProgress: (Float) -> Unit): ApkInstaller.Result =
         coroutineScope {
             try {
+                val prefs = context.dataStore.data.first()
                 val uris = if (isBundle) compatibleSplits(uri) else listOf(uri)
                 require(uris.isNotEmpty()) { "No APK found in bundle" }
                 val session = PackageInstaller.getInstance(context).createSession(uris) {
                     confirmation = Confirmation.IMMEDIATE
-                    shizuku { replaceExisting = true }
+                    shizuku {
+                        replaceExisting = prefs[SharedPrefsKeys.TV_SHIZUKU_REPLACE] ?: true
+                        requestDowngrade = prefs[SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE] ?: false
+                        grantAllRequestedPermissions = prefs[SharedPrefsKeys.TV_SHIZUKU_GRANT] ?: false
+                        allowTest = prefs[SharedPrefsKeys.TV_SHIZUKU_TEST] ?: false
+                        allUsers = prefs[SharedPrefsKeys.TV_SHIZUKU_ALL_USERS] ?: false
+                    }
                 }
                 val progressJob = launch {
                     session.progress.collect {

--- a/tv/src/main/java/app/pwhs/tv/install/TvInstallBackend.kt
+++ b/tv/src/main/java/app/pwhs/tv/install/TvInstallBackend.kt
@@ -1,0 +1,19 @@
+package app.pwhs.tv.install
+
+/** Resolve once per install; never probe root when the chosen Shizuku service is ready. */
+internal enum class TvInstallBackend {
+    Shizuku, Root, System;
+
+    companion object {
+        suspend fun select(
+            shizukuEnabled: Boolean,
+            rootEnabled: Boolean,
+            shizukuReady: () -> Boolean,
+            rootReady: suspend () -> Boolean,
+        ): TvInstallBackend = when {
+            shizukuEnabled && shizukuReady() -> Shizuku
+            rootEnabled && rootReady() -> Root
+            else -> System
+        }
+    }
+}

--- a/tv/src/main/java/app/pwhs/tv/install/TvShizuku.kt
+++ b/tv/src/main/java/app/pwhs/tv/install/TvShizuku.kt
@@ -1,0 +1,30 @@
+package app.pwhs.tv.install
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import rikka.shizuku.Shizuku
+
+/** Binder readiness is authoritative, including for compatible TV manager forks. */
+object TvShizuku {
+    val enabledKey = booleanPreferencesKey("tv_shizuku_enabled")
+    const val PERMISSION_REQUEST = 70
+
+    enum class Status { Missing, Stopped, Unsupported, PermissionRequired, Ready }
+
+    fun status(context: Context): Status = try {
+        when {
+            !Shizuku.pingBinder() -> {
+                val installed = runCatching {
+                    context.packageManager.getPackageInfo("moe.shizuku.privileged.api", 0)
+                }.isSuccess
+                if (installed) Status.Stopped else Status.Missing
+            }
+            Shizuku.isPreV11() -> Status.Unsupported
+            Shizuku.checkSelfPermission() != PackageManager.PERMISSION_GRANTED -> Status.PermissionRequired
+            else -> Status.Ready
+        }
+    } catch (_: Exception) {
+        Status.Stopped
+    }
+}

--- a/tv/src/main/java/app/pwhs/tv/presentation/receive/ReceiveViewModel.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/receive/ReceiveViewModel.kt
@@ -11,6 +11,9 @@ import app.pwhs.core.data.local.dataStore
 import app.pwhs.core.domain.ApkFile
 import app.pwhs.core.install.ApkInstaller
 import app.pwhs.core.install.RootInstaller
+import app.pwhs.tv.install.TvInstallBackend
+import app.pwhs.tv.install.TvShizuku
+import app.pwhs.tv.install.ShizukuInstaller
 import app.pwhs.core.receiver.ConnectedClient
 import app.pwhs.core.receiver.ReceivedApk
 import app.pwhs.core.receiver.ReceivingProgress
@@ -38,6 +41,7 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
     private val metadataReader = ApkMetadataReader(context)
     private val installer = ApkInstaller(context)
     private val rootInstaller = RootInstaller(context)
+    private val shizukuInstaller = ShizukuInstaller(context)
 
     val status: StateFlow<ReceiverStatus> = TvReceiverState.status
     val connectedClient: StateFlow<ConnectedClient?> = TvReceiverState.connectedClient
@@ -153,15 +157,22 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
             _installResult.value = null
             _installingLabel.value = label
             _installProgress.value = if (sizeBytes > 0) 0f else null
-            // Prefer the silent root path on rooted boxes (skips the D-pad-hostile system dialog);
-            // fall back to the PackageInstaller session when root is off or unavailable.
-            val silentPref = runCatching {
-                context.dataStore.data.first()[SharedPrefsKeys.ROOT_SILENT_INSTALL]
-            }.getOrNull() ?: true
-            val useRoot = silentPref && RootShell.isAvailable()
+            val prefs = context.dataStore.data.first()
+            val backend = TvInstallBackend.select(
+                shizukuEnabled = prefs[TvShizuku.enabledKey] ?: false,
+                rootEnabled = prefs[SharedPrefsKeys.ROOT_SILENT_INSTALL] ?: true,
+                shizukuReady = { TvShizuku.status(context) == TvShizuku.Status.Ready },
+                rootReady = { RootShell.isAvailable() },
+            )
+            val useShizuku = backend == TvInstallBackend.Shizuku
+            val useRoot = backend == TvInstallBackend.Root
             val startTime = System.currentTimeMillis()
             val ext = uri.lastPathSegment?.substringAfterLast('.', "") ?: "apk"
-            val installMode = if (useRoot) TelemetryEvents.MODE_ROOT else TelemetryEvents.MODE_SESSION_INSTALLER
+            val installMode = when {
+                useShizuku -> TelemetryEvents.MODE_SHIZUKU
+                useRoot -> TelemetryEvents.MODE_ROOT
+                else -> TelemetryEvents.MODE_SESSION_INSTALLER
+            }
             AnalyticsHelper.logInstallStarted(
                 fileType = ext,
                 installMode = installMode,
@@ -169,7 +180,9 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
                 fileSizeBytes = sizeBytes
             )
             val result = withContext(Dispatchers.IO) {
-                if (useRoot) {
+                if (useShizuku) {
+                    shizukuInstaller.install(uri, isBundle) { _installProgress.value = it }
+                } else if (useRoot) {
                     rootInstaller.install(uri, isBundle) { f -> _installProgress.value = f }
                 } else {
                     installer.install(uri, isBundle, totalBytes = sizeBytes) { written, total ->
@@ -192,7 +205,7 @@ class ReceiveViewModel(application: Application) : AndroidViewModel(application)
             _installResult.value = when (result) {
                 is ApkInstaller.Result.Success -> {
                     _pendingApk.value = null // received APK is installed — clear the hero so the QR returns
-                    InstallOutcome.Success(label, silent = useRoot)
+                    InstallOutcome.Success(label, silent = useRoot || useShizuku)
                 }
                 is ApkInstaller.Result.Failure -> InstallOutcome.Failure(label, result.message)
             }

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -1,7 +1,9 @@
 package app.pwhs.tv.presentation.settings
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -20,6 +22,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.Surface
+import androidx.tv.material3.Switch
 import app.pwhs.core.data.local.SharedPrefsKeys
 import app.pwhs.core.data.local.dataStore
 import androidx.compose.ui.platform.LocalContext
@@ -61,7 +64,13 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun OptionRow(label: String, checked: Boolean, onClick: () -> Unit) {
-    Surface(onClick = onClick, modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
-        Text(if (checked) "✓  $label: On" else "$label: Off", modifier = Modifier.padding(20.dp), style = MaterialTheme.typography.titleLarge)
+    Surface(onClick = onClick, modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(label, style = MaterialTheme.typography.titleLarge)
+            Switch(checked = checked, onCheckedChange = { onClick() })
+        }
     }
 }

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -1,0 +1,67 @@
+package app.pwhs.tv.presentation.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Icon
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.Surface
+import app.pwhs.core.data.local.SharedPrefsKeys
+import app.pwhs.core.data.local.dataStore
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun InstallOptionsScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val prefs by context.dataStore.data.collectAsState(initial = null)
+    val root = prefs?.let { it[SharedPrefsKeys.TV_ROOT_REPLACE] ?: true } ?: true
+    val shizuku = prefs?.let { it[SharedPrefsKeys.TV_SHIZUKU_REPLACE] ?: true } ?: true
+    fun set(key: androidx.datastore.preferences.core.Preferences.Key<Boolean>, value: Boolean) = scope.launch {
+        context.dataStore.updateData { it.toMutablePreferences().apply { this[key] = value } }
+    }
+    LazyColumn(Modifier.fillMaxSize().padding(horizontal = 48.dp), contentPadding = PaddingValues(32.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        item { Surface(onClick = onBack, scale = ClickableSurfaceDefaults.scale()) { Icon(Icons.Default.ArrowBack, "Back") } }
+        item { Text("Install options", style = MaterialTheme.typography.displaySmall) }
+        item { Text("These options are stored separately for Shizuku and Root.", style = MaterialTheme.typography.bodyLarge) }
+        item { Text("Shizuku", style = MaterialTheme.typography.headlineSmall) }
+        item { OptionRow("Replace existing", shizuku) { set(SharedPrefsKeys.TV_SHIZUKU_REPLACE, !shizuku) } }
+        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false)) } }
+        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_GRANT, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false)) } }
+        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_TEST, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false)) } }
+        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false)) } }
+        item { Text("Root", style = MaterialTheme.typography.headlineSmall) }
+        item { OptionRow("Replace existing", root) { set(SharedPrefsKeys.TV_ROOT_REPLACE, !root) } }
+        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false) { set(SharedPrefsKeys.TV_ROOT_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false)) } }
+        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false) { set(SharedPrefsKeys.TV_ROOT_GRANT, !(prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false)) } }
+        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false) { set(SharedPrefsKeys.TV_ROOT_TEST, !(prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false)) } }
+        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false) { set(SharedPrefsKeys.TV_ROOT_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false)) } }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun OptionRow(label: String, checked: Boolean, onClick: () -> Unit) {
+    Surface(onClick = onClick, modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
+        Text(if (checked) "✓  $label: On" else "$label: Off", modifier = Modifier.padding(20.dp), style = MaterialTheme.typography.titleLarge)
+    }
+}

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -75,20 +75,15 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
 @Composable
 private fun OptionRow(label: String, checked: Boolean, enabled: Boolean, onClick: () -> Unit) {
     val surface = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f)
-    Surface(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)),
-        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
-        colors = ClickableSurfaceDefaults.colors(
+    val colors = ClickableSurfaceDefaults.colors(
             containerColor = surface,
             focusedContainerColor = surface,
             contentColor = MaterialTheme.colorScheme.onSurface,
             focusedContentColor = MaterialTheme.colorScheme.onSurface,
             disabledContainerColor = surface.copy(alpha = .22f),
             disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .42f),
-        ),
-    ) {
+        )
+    val content: @Composable () -> Unit = {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -96,5 +91,10 @@ private fun OptionRow(label: String, checked: Boolean, enabled: Boolean, onClick
             Text(label, style = MaterialTheme.typography.titleLarge, color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = .45f))
             Switch(checked = checked, enabled = enabled, onCheckedChange = { onClick() })
         }
+    }
+    if (enabled) {
+        Surface(onClick = onClick, modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)), scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f), colors = colors) { content() }
+    } else {
+        Surface(modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))) { content() }
     }
 }

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -74,7 +74,20 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun OptionRow(label: String, checked: Boolean, enabled: Boolean, onClick: () -> Unit) {
-    Surface(onClick = onClick, enabled = enabled, modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
+    val surface = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f)
+    Surface(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = surface,
+            focusedContainerColor = surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            focusedContentColor = MaterialTheme.colorScheme.onSurface,
+            disabledContainerColor = surface.copy(alpha = .22f),
+            disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .42f),
+        ),
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -51,7 +51,7 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
         context.dataStore.updateData { it.toMutablePreferences().apply { this[key] = value } }
     }
     LazyColumn(Modifier.fillMaxSize().padding(horizontal = 48.dp), contentPadding = PaddingValues(32.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        item { Surface(onClick = onBack, scale = ClickableSurfaceDefaults.scale()) { Icon(Icons.Default.ArrowBack, "Back") } }
+        item { Surface(onClick = onBack, scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f)) { Icon(Icons.Default.ArrowBack, "Back") } }
         item { Text("Install options", style = MaterialTheme.typography.displaySmall) }
         item { Text("These options are stored separately for Shizuku and Root.", style = MaterialTheme.typography.bodyLarge) }
         item { Text("Shizuku", style = MaterialTheme.typography.headlineSmall) }
@@ -79,6 +79,7 @@ private fun OptionRow(label: String, checked: Boolean, enabled: Boolean, onClick
         onClick = onClick,
         enabled = enabled,
         modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
         colors = ClickableSurfaceDefaults.colors(
             containerColor = surface,
             focusedContainerColor = surface,

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/InstallOptionsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,6 +26,8 @@ import androidx.tv.material3.Surface
 import androidx.tv.material3.Switch
 import app.pwhs.core.data.local.SharedPrefsKeys
 import app.pwhs.core.data.local.dataStore
+import app.pwhs.core.util.RootShell
+import app.pwhs.tv.install.TvShizuku
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
@@ -37,6 +40,11 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val prefs by context.dataStore.data.collectAsState(initial = null)
+    val rootReady by produceState<Boolean?>(initialValue = null) { value = RootShell.isAvailable() }
+    val shizukuStatus by produceState(initialValue = TvShizuku.Status.Stopped) {
+        value = TvShizuku.status(context)
+    }
+    val shizukuReady = shizukuStatus == TvShizuku.Status.Ready
     val root = prefs?.let { it[SharedPrefsKeys.TV_ROOT_REPLACE] ?: true } ?: true
     val shizuku = prefs?.let { it[SharedPrefsKeys.TV_SHIZUKU_REPLACE] ?: true } ?: true
     fun set(key: androidx.datastore.preferences.core.Preferences.Key<Boolean>, value: Boolean) = scope.launch {
@@ -47,30 +55,32 @@ fun InstallOptionsScreen(onBack: () -> Unit) {
         item { Text("Install options", style = MaterialTheme.typography.displaySmall) }
         item { Text("These options are stored separately for Shizuku and Root.", style = MaterialTheme.typography.bodyLarge) }
         item { Text("Shizuku", style = MaterialTheme.typography.headlineSmall) }
-        item { OptionRow("Replace existing", shizuku) { set(SharedPrefsKeys.TV_SHIZUKU_REPLACE, !shizuku) } }
-        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false)) } }
-        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_GRANT, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false)) } }
-        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_TEST, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false)) } }
-        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false) { set(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false)) } }
+        item { Text(if (shizukuReady) "Ready" else "Unavailable — start Shizuku and grant permission first", style = MaterialTheme.typography.bodyMedium) }
+        item { OptionRow("Replace existing", shizuku, shizukuReady) { set(SharedPrefsKeys.TV_SHIZUKU_REPLACE, !shizuku) } }
+        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false, shizukuReady) { set(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_DOWNGRADE) ?: false)) } }
+        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false, shizukuReady) { set(SharedPrefsKeys.TV_SHIZUKU_GRANT, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_GRANT) ?: false)) } }
+        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false, shizukuReady) { set(SharedPrefsKeys.TV_SHIZUKU_TEST, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_TEST) ?: false)) } }
+        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false, shizukuReady) { set(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_SHIZUKU_ALL_USERS) ?: false)) } }
         item { Text("Root", style = MaterialTheme.typography.headlineSmall) }
-        item { OptionRow("Replace existing", root) { set(SharedPrefsKeys.TV_ROOT_REPLACE, !root) } }
-        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false) { set(SharedPrefsKeys.TV_ROOT_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false)) } }
-        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false) { set(SharedPrefsKeys.TV_ROOT_GRANT, !(prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false)) } }
-        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false) { set(SharedPrefsKeys.TV_ROOT_TEST, !(prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false)) } }
-        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false) { set(SharedPrefsKeys.TV_ROOT_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false)) } }
+        item { Text(if (rootReady == true) "Ready" else "Unavailable — grant root access first", style = MaterialTheme.typography.bodyMedium) }
+        item { OptionRow("Replace existing", root, rootReady == true) { set(SharedPrefsKeys.TV_ROOT_REPLACE, !root) } }
+        item { OptionRow("Allow downgrade", prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false, rootReady == true) { set(SharedPrefsKeys.TV_ROOT_DOWNGRADE, !(prefs?.get(SharedPrefsKeys.TV_ROOT_DOWNGRADE) ?: false)) } }
+        item { OptionRow("Grant all requested permissions", prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false, rootReady == true) { set(SharedPrefsKeys.TV_ROOT_GRANT, !(prefs?.get(SharedPrefsKeys.TV_ROOT_GRANT) ?: false)) } }
+        item { OptionRow("Allow test APKs", prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false, rootReady == true) { set(SharedPrefsKeys.TV_ROOT_TEST, !(prefs?.get(SharedPrefsKeys.TV_ROOT_TEST) ?: false)) } }
+        item { OptionRow("Install for all users", prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false, rootReady == true) { set(SharedPrefsKeys.TV_ROOT_ALL_USERS, !(prefs?.get(SharedPrefsKeys.TV_ROOT_ALL_USERS) ?: false)) } }
     }
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun OptionRow(label: String, checked: Boolean, onClick: () -> Unit) {
-    Surface(onClick = onClick, modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
+private fun OptionRow(label: String, checked: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    Surface(onClick = onClick, enabled = enabled, modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp)), colors = ClickableSurfaceDefaults.colors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = .45f))) {
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Text(label, style = MaterialTheme.typography.titleLarge)
-            Switch(checked = checked, onCheckedChange = { onClick() })
+            Text(label, style = MaterialTheme.typography.titleLarge, color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = .45f))
+            Switch(checked = checked, enabled = enabled, onCheckedChange = { onClick() })
         }
     }
 }

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -220,7 +220,7 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             val silentEnabled by context.dataStore.data
                 .map { it[SharedPrefsKeys.ROOT_SILENT_INSTALL] ?: true }
                 .collectAsState(initial = true)
-            SettingsCard(onClick = {
+            SettingsCard(enabled = rootAvailable == true, onClick = {
                 scope.launch {
                     context.dataStore.edit { it[SharedPrefsKeys.ROOT_SILENT_INSTALL] = !silentEnabled }
                 }
@@ -406,10 +406,11 @@ private fun ThemeOptionCard(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-internal fun SettingsCard(onClick: () -> Unit, content: @Composable () -> Unit) {
+internal fun SettingsCard(enabled: Boolean = true, onClick: () -> Unit, content: @Composable () -> Unit) {
     val shape = RoundedCornerShape(20.dp)
     Surface(
         onClick = onClick,
+        enabled = enabled,
         modifier = Modifier
             .fillMaxWidth()
             .clip(shape),

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -408,22 +408,17 @@ private fun ThemeOptionCard(
 @Composable
 internal fun SettingsCard(enabled: Boolean = true, onClick: () -> Unit, content: @Composable () -> Unit) {
     val shape = RoundedCornerShape(20.dp)
-    Surface(
-        onClick = onClick,
-        enabled = enabled,
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(shape),
-        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.03f),
-        shape = ClickableSurfaceDefaults.shape(shape),
-        colors = ClickableSurfaceDefaults.colors(
+    val colors = ClickableSurfaceDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
             focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
             contentColor = MaterialTheme.colorScheme.onSurface,
             focusedContentColor = MaterialTheme.colorScheme.onSurface
         )
-    ) {
-        Column(Modifier.padding(24.dp)) { content() }
+    val body: @Composable () -> Unit = { Column(Modifier.padding(24.dp)) { content() } }
+    if (enabled) {
+        Surface(onClick = onClick, modifier = Modifier.fillMaxWidth().clip(shape), scale = ClickableSurfaceDefaults.scale(focusedScale = 1.03f), shape = ClickableSurfaceDefaults.shape(shape), colors = colors) { body() }
+    } else {
+        Surface(modifier = Modifier.fillMaxWidth().clip(shape)) { body() }
     }
 }
 

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -387,9 +387,9 @@ private fun ThemeOptionCard(
         shape = ClickableSurfaceDefaults.shape(shape),
         colors = ClickableSurfaceDefaults.colors(
             containerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-            focusedContainerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.8f),
+            focusedContainerColor = if (selected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.primary.copy(alpha = 0.82f),
             contentColor = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurface,
-            focusedContentColor = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.primary
+            focusedContentColor = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onPrimary
         )
     ) {
         Column(

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -239,6 +239,8 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
             }
         }
 
+        item { ShizukuSetting() }
+
         // ── Device Info ──────────────────────────────────────────────────────
         item { SectionHeader(stringResource(R.string.tv_settings_section_device), Icons.Default.Devices) }
         item {
@@ -394,7 +396,7 @@ private fun ThemeOptionCard(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun SettingsCard(onClick: () -> Unit, content: @Composable () -> Unit) {
+internal fun SettingsCard(onClick: () -> Unit, content: @Composable () -> Unit) {
     val shape = RoundedCornerShape(20.dp)
     Surface(
         onClick = onClick,
@@ -416,7 +418,7 @@ private fun SettingsCard(onClick: () -> Unit, content: @Composable () -> Unit) {
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun TitleValue(title: String, value: String) {
+internal fun TitleValue(title: String, value: String) {
     Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
     Spacer(Modifier.height(4.dp))
     Text(

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.foundation.border
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -350,10 +352,15 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
 @Composable
 private fun AccentSwatch(color: Color, selected: Boolean, onClick: () -> Unit) {
     val shape = CircleShape
+    var focused by remember { mutableStateOf(false) }
     Surface(
         onClick = onClick,
-        modifier = Modifier.size(64.dp).clip(shape),
-        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.12f),
+        modifier = Modifier
+            .size(64.dp)
+            .onFocusChanged { focused = it.isFocused }
+            .border(if (focused) 3.dp else 0.dp, Color.White, shape)
+            .clip(shape),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.05f),
         shape = ClickableSurfaceDefaults.shape(shape),
         colors = ClickableSurfaceDefaults.colors(containerColor = color, focusedContainerColor = color),
     ) {

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/SettingsScreen.kt
@@ -80,9 +80,14 @@ private const val REPO_URL = "https://github.com/pass-with-high-score/universal-
 @Composable
 fun SettingsScreen(modifier: Modifier = Modifier) {
     var showLanguageScreen by remember { mutableStateOf(false) }
+    var showInstallOptions by remember { mutableStateOf(false) }
 
     if (showLanguageScreen) {
         LanguageScreen(onBack = { showLanguageScreen = false })
+        return
+    }
+    if (showInstallOptions) {
+        InstallOptionsScreen(onBack = { showInstallOptions = false })
         return
     }
     val context = LocalContext.current
@@ -240,6 +245,11 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
         }
 
         item { ShizukuSetting() }
+        item {
+            SettingsCard(onClick = { showInstallOptions = true }) {
+                TitleValue("Install options", "Configure Shizuku and Root flags")
+            }
+        }
 
         // ── Device Info ──────────────────────────────────────────────────────
         item { SectionHeader(stringResource(R.string.tv_settings_section_device), Icons.Default.Devices) }
@@ -450,4 +460,3 @@ private fun SectionHeader(text: String, icon: androidx.compose.ui.graphics.vecto
         )
     }
 }
-

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/ShizukuSetting.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/ShizukuSetting.kt
@@ -1,0 +1,53 @@
+package app.pwhs.tv.presentation.settings
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import app.pwhs.tv.R
+import app.pwhs.tv.install.TvShizuku
+
+@Composable
+internal fun ShizukuSetting(model: ShizukuSettingsViewModel = viewModel()) {
+    val enabled by model.enabled.collectAsState()
+    val status by model.status.collectAsState()
+    val message by model.message.collectAsState()
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(lifecycle, model) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) model.refresh()
+        }
+        lifecycle.addObserver(observer)
+        model.refresh()
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+    SettingsCard(onClick = model::toggle) {
+        TitleValue(
+            stringResource(R.string.tv_shizuku_title),
+            stringResource(if (enabled) R.string.tv_shizuku_on else R.string.tv_shizuku_off),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            stringResource(message ?: when (status) {
+                TvShizuku.Status.Missing -> R.string.tv_shizuku_missing
+                TvShizuku.Status.Stopped -> R.string.tv_shizuku_stopped
+                TvShizuku.Status.Unsupported -> R.string.tv_shizuku_unsupported
+                TvShizuku.Status.PermissionRequired -> R.string.tv_shizuku_permission
+                TvShizuku.Status.Ready -> R.string.tv_shizuku_ready
+            }),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/tv/src/main/java/app/pwhs/tv/presentation/settings/ShizukuSettingsViewModel.kt
+++ b/tv/src/main/java/app/pwhs/tv/presentation/settings/ShizukuSettingsViewModel.kt
@@ -1,0 +1,77 @@
+package app.pwhs.tv.presentation.settings
+
+import android.app.Application
+import android.content.pm.PackageManager
+import androidx.datastore.preferences.core.edit
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import app.pwhs.core.data.local.dataStore
+import app.pwhs.tv.R
+import app.pwhs.tv.install.TvShizuku
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import rikka.shizuku.Shizuku
+
+class ShizukuSettingsViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+    val enabled = context.dataStore.data.map { it[TvShizuku.enabledKey] ?: false }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+    private val _status = MutableStateFlow(TvShizuku.status(context))
+    val status: kotlinx.coroutines.flow.StateFlow<TvShizuku.Status> = _status.asStateFlow()
+    private val _message = MutableStateFlow<Int?>(null)
+    val message = _message.asStateFlow()
+    private var requesting = false
+    private val received = Shizuku.OnBinderReceivedListener { refresh() }
+    private val dead = Shizuku.OnBinderDeadListener { refresh() }
+    private val permission = Shizuku.OnRequestPermissionResultListener { code, grant ->
+        if (code == TvShizuku.PERMISSION_REQUEST && requesting) {
+            requesting = false
+            refresh()
+            if (grant == PackageManager.PERMISSION_GRANTED) setEnabled(true)
+            else _message.value = R.string.tv_shizuku_denied
+        }
+    }
+
+    init {
+        Shizuku.addBinderReceivedListenerSticky(received)
+        Shizuku.addBinderDeadListener(dead)
+        Shizuku.addRequestPermissionResultListener(permission)
+    }
+
+    fun refresh() { _status.value = TvShizuku.status(context) }
+
+    fun toggle() {
+        _message.value = null
+        refresh()
+        if (enabled.value) {
+            setEnabled(false)
+        } else when (status.value) {
+            TvShizuku.Status.Ready -> setEnabled(true)
+            TvShizuku.Status.PermissionRequired -> {
+                if (requesting) return
+                requesting = true
+                try {
+                    Shizuku.requestPermission(TvShizuku.PERMISSION_REQUEST)
+                } catch (_: Exception) {
+                    requesting = false
+                    _message.value = R.string.tv_shizuku_error
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    private fun setEnabled(value: Boolean) {
+        viewModelScope.launch { context.dataStore.edit { it[TvShizuku.enabledKey] = value } }
+    }
+
+    override fun onCleared() {
+        Shizuku.removeBinderReceivedListener(received)
+        Shizuku.removeBinderDeadListener(dead)
+        Shizuku.removeRequestPermissionResultListener(permission)
+    }
+}

--- a/tv/src/main/res/values-ar/strings.xml
+++ b/tv/src/main/res/values-ar/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / الكمبيوتر: امسح رمز الاستجابة السريعة أو افتح الرابط أعلاه</string>
     <string name="tv_receive_btn_disconnect">قطع الاتصال</string>
     <string name="tv_receive_step3">جاهز للتثبيت</string>
+    <string name="tv_shizuku_missing">Shizuku غير مثبت</string>
+    <string name="tv_shizuku_stopped">Shizuku مثبت ولكنه لا يعمل</string>
+    <string name="tv_shizuku_unsupported">إصدار Shizuku قديم جدًا (قبل v11)</string>
+    <string name="tv_shizuku_permission">اضغط لمنح إذن Shizuku</string>
+    <string name="tv_shizuku_ready">تثبيت صامت بدون مطالبات</string>
+    <string name="tv_shizuku_denied">تم رفض إذن Shizuku</string>
+    <string name="tv_shizuku_on">مفعّل — تفضيل Shizuku للتثبيت الصامت</string>
+    <string name="tv_shizuku_off">معطّل — اختر لتفعيل Shizuku</string>
+    <string name="tv_shizuku_error">تعذر طلب الإذن. افتح Shizuku وحاول مرة أخرى.</string>
 </resources>

--- a/tv/src/main/res/values-de/strings.xml
+++ b/tv/src/main/res/values-de/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: QR-Code scannen oder obigen Link öffnen</string>
     <string name="tv_receive_btn_disconnect">Trennen</string>
     <string name="tv_receive_step3">Bereit zur Installation</string>
+    <string name="tv_shizuku_missing">Shizuku nicht installiert</string>
+    <string name="tv_shizuku_stopped">Shizuku installiert, läuft aber nicht</string>
+    <string name="tv_shizuku_unsupported">Shizuku-Version zu alt (vor v11)</string>
+    <string name="tv_shizuku_permission">Tippen, um Shizuku-Berechtigung zu erteilen</string>
+    <string name="tv_shizuku_ready">Stille Installation ohne Bestätigung</string>
+    <string name="tv_shizuku_denied">Shizuku-Berechtigung wurde verweigert</string>
+    <string name="tv_shizuku_on">Ein — Shizuku für stille Installation bevorzugen</string>
+    <string name="tv_shizuku_off">Aus — auswählen, um Shizuku zu aktivieren</string>
+    <string name="tv_shizuku_error">Berechtigung konnte nicht angefordert werden. Shizuku öffnen und erneut versuchen.</string>
 </resources>

--- a/tv/src/main/res/values-el/strings.xml
+++ b/tv/src/main/res/values-el/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Σαρώστε το QR ή ανοίξτε τον παραπάνω σύνδεσμο</string>
     <string name="tv_receive_btn_disconnect">Αποσύνδεση</string>
     <string name="tv_receive_step3">Έτοιμο για εγκατάσταση</string>
+    <string name="tv_shizuku_missing">Το Shizuku δεν είναι εγκατεστημένο</string>
+    <string name="tv_shizuku_stopped">Το Shizuku είναι εγκατεστημένο αλλά δεν εκτελείται</string>
+    <string name="tv_shizuku_unsupported">Η έκδοση Shizuku είναι πολύ παλιά (πριν την v11)</string>
+    <string name="tv_shizuku_permission">Πατήστε για παραχώρηση άδειας Shizuku</string>
+    <string name="tv_shizuku_ready">Αθόρυβη εγκατάσταση χωρίς μηνύματα</string>
+    <string name="tv_shizuku_denied">Η άδεια Shizuku απορρίφθηκε</string>
+    <string name="tv_shizuku_on">Ενεργό — προτίμηση Shizuku για αθόρυβη εγκατάσταση</string>
+    <string name="tv_shizuku_off">Ανενεργό — επιλέξτε για ενεργοποίηση του Shizuku</string>
+    <string name="tv_shizuku_error">Δεν ήταν δυνατή η αίτηση άδειας. Ανοίξτε το Shizuku και δοκιμάστε ξανά.</string>
 </resources>

--- a/tv/src/main/res/values-es/strings.xml
+++ b/tv/src/main/res/values-es/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Escanee el código QR o abra el enlace anterior</string>
     <string name="tv_receive_btn_disconnect">Desconectar</string>
     <string name="tv_receive_step3">Listo para instalar</string>
+    <string name="tv_shizuku_missing">Shizuku no está instalado</string>
+    <string name="tv_shizuku_stopped">Shizuku está instalado pero no se está ejecutando</string>
+    <string name="tv_shizuku_unsupported">La versión de Shizuku es demasiado antigua (anterior a la v11)</string>
+    <string name="tv_shizuku_permission">Toca para conceder el permiso de Shizuku</string>
+    <string name="tv_shizuku_ready">Instalación silenciosa sin avisos</string>
+    <string name="tv_shizuku_denied">Se denegó el permiso de Shizuku</string>
+    <string name="tv_shizuku_on">Activado — preferir Shizuku para instalar sin confirmación</string>
+    <string name="tv_shizuku_off">Desactivado — selecciona para activar Shizuku</string>
+    <string name="tv_shizuku_error">No se pudo solicitar el permiso. Abre Shizuku e inténtalo de nuevo.</string>
 </resources>

--- a/tv/src/main/res/values-fr/strings.xml
+++ b/tv/src/main/res/values-fr/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC : Scannez le code QR ou ouvrez le lien ci-dessus</string>
     <string name="tv_receive_btn_disconnect">Déconnecter</string>
     <string name="tv_receive_step3">Prêt à installer</string>
+    <string name="tv_shizuku_missing">Shizuku non installé</string>
+    <string name="tv_shizuku_stopped">Shizuku installé mais ne fonctionne pas</string>
+    <string name="tv_shizuku_unsupported">Version de Shizuku trop ancienne (pré-v11)</string>
+    <string name="tv_shizuku_permission">Appuyez pour accorder la permission Shizuku</string>
+    <string name="tv_shizuku_ready">Installation silencieuse sans invites</string>
+    <string name="tv_shizuku_denied">L\'autorisation Shizuku a été refusée</string>
+    <string name="tv_shizuku_on">Activé — privilégier Shizuku pour une installation silencieuse</string>
+    <string name="tv_shizuku_off">Désactivé — sélectionner pour activer Shizuku</string>
+    <string name="tv_shizuku_error">Impossible de demander la permission. Ouvrez Shizuku et réessayez.</string>
 </resources>

--- a/tv/src/main/res/values-hi/strings.xml
+++ b/tv/src/main/res/values-hi/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: क्यूआर कोड स्कैन करें या ऊपर दिया गया लिंक खोलें</string>
     <string name="tv_receive_btn_disconnect">डिस्कनेक्ट करें</string>
     <string name="tv_receive_step3">इंस्टॉल करने के लिए तैयार</string>
+    <string name="tv_shizuku_missing">Shizuku इंस्टॉल नहीं है</string>
+    <string name="tv_shizuku_stopped">Shizuku इंस्टॉल है लेकिन चल नहीं रहा है</string>
+    <string name="tv_shizuku_unsupported">Shizuku वर्ज़न बहुत पुराना है (pre-v11)</string>
+    <string name="tv_shizuku_permission">Shizuku अनुमति देने के लिए टैप करें</string>
+    <string name="tv_shizuku_ready">बिना प्रांप्ट के साइलेंट इंस्टॉल</string>
+    <string name="tv_shizuku_denied">Shizuku अनुमति अस्वीकार कर दी गई थी</string>
+    <string name="tv_shizuku_on">चालू — बिना पुष्टि के इंस्टॉल करने के लिए Shizuku को प्राथमिकता दें</string>
+    <string name="tv_shizuku_off">बंद — Shizuku चालू करने के लिए चुनें</string>
+    <string name="tv_shizuku_error">अनुमति का अनुरोध नहीं हो सका। Shizuku खोलें और फिर कोशिश करें।</string>
 </resources>

--- a/tv/src/main/res/values-in/strings.xml
+++ b/tv/src/main/res/values-in/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Pindai kode QR atau buka tautan di atas</string>
     <string name="tv_receive_btn_disconnect">Putuskan</string>
     <string name="tv_receive_step3">Siap dipasang</string>
+    <string name="tv_shizuku_missing">Shizuku tidak terinstal</string>
+    <string name="tv_shizuku_stopped">Shizuku terinstal tetapi tidak berjalan</string>
+    <string name="tv_shizuku_unsupported">Versi Shizuku terlalu lama (sebelum v11)</string>
+    <string name="tv_shizuku_permission">Ketuk untuk memberikan izin Shizuku</string>
+    <string name="tv_shizuku_ready">Instalasi diam-diam tanpa konfirmasi</string>
+    <string name="tv_shizuku_denied">Izin Shizuku ditolak</string>
+    <string name="tv_shizuku_on">Aktif — utamakan Shizuku untuk instalasi senyap</string>
+    <string name="tv_shizuku_off">Nonaktif — pilih untuk mengaktifkan Shizuku</string>
+    <string name="tv_shizuku_error">Tidak dapat meminta izin. Buka Shizuku dan coba lagi.</string>
 </resources>

--- a/tv/src/main/res/values-it/strings.xml
+++ b/tv/src/main/res/values-it/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Scansiona il codice QR o apri il link sopra</string>
     <string name="tv_receive_btn_disconnect">Disconnetti</string>
     <string name="tv_receive_step3">Pronto per l\'installazione</string>
+    <string name="tv_shizuku_missing">Shizuku non installato</string>
+    <string name="tv_shizuku_stopped">Shizuku installato ma non in esecuzione</string>
+    <string name="tv_shizuku_unsupported">Versione Shizuku troppo vecchia (pre-v11)</string>
+    <string name="tv_shizuku_permission">Tocca per concedere l\'autorizzazione a Shizuku</string>
+    <string name="tv_shizuku_ready">Installazione silenziosa senza prompt</string>
+    <string name="tv_shizuku_denied">L\'autorizzazione Shizuku è stata negata</string>
+    <string name="tv_shizuku_on">Attivo — preferisci Shizuku per installazioni silenziose</string>
+    <string name="tv_shizuku_off">Disattivo — seleziona per attivare Shizuku</string>
+    <string name="tv_shizuku_error">Impossibile richiedere il permesso. Apri Shizuku e riprova.</string>
 </resources>

--- a/tv/src/main/res/values-ja/strings.xml
+++ b/tv/src/main/res/values-ja/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: QRコードをスキャンまたは上記リンクを開く</string>
     <string name="tv_receive_btn_disconnect">切断</string>
     <string name="tv_receive_step3">インストールの準備完了</string>
+    <string name="tv_shizuku_missing">Shizuku がインストールされていません</string>
+    <string name="tv_shizuku_stopped">Shizuku はインストールされていますが実行されていません</string>
+    <string name="tv_shizuku_unsupported">Shizuku のバージョンが古すぎます（v11 未満）</string>
+    <string name="tv_shizuku_permission">タップして Shizuku に権限を付与</string>
+    <string name="tv_shizuku_ready">プロンプトなしのサイレントインストール</string>
+    <string name="tv_shizuku_denied">Shizuku の権限が拒否されました</string>
+    <string name="tv_shizuku_on">オン — サイレントインストールに Shizuku を優先</string>
+    <string name="tv_shizuku_off">オフ — 選択して Shizuku を有効にする</string>
+    <string name="tv_shizuku_error">権限を要求できませんでした。Shizuku を開いて再試行してください。</string>
 </resources>

--- a/tv/src/main/res/values-ko/strings.xml
+++ b/tv/src/main/res/values-ko/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: QR 코드를 스캔하거나 위의 링크 열기</string>
     <string name="tv_receive_btn_disconnect">연결 해제</string>
     <string name="tv_receive_step3">설치 준비 완료</string>
+    <string name="tv_shizuku_missing">Shizuku가 설치되지 않음</string>
+    <string name="tv_shizuku_stopped">Shizuku가 설치되었지만 실행 중이 아님</string>
+    <string name="tv_shizuku_unsupported">Shizuku 버전이 너무 낮음 (v11 이전)</string>
+    <string name="tv_shizuku_permission">탭하여 Shizuku 권한 부여</string>
+    <string name="tv_shizuku_ready">프롬프트 없는 자동 설치</string>
+    <string name="tv_shizuku_denied">Shizuku 권한이 거부되었습니다</string>
+    <string name="tv_shizuku_on">켜짐 — 자동 설치에 Shizuku 우선 사용</string>
+    <string name="tv_shizuku_off">꺼짐 — 선택하여 Shizuku 활성화</string>
+    <string name="tv_shizuku_error">권한을 요청할 수 없습니다. Shizuku를 열고 다시 시도하세요.</string>
 </resources>

--- a/tv/src/main/res/values-pt-rBR/strings.xml
+++ b/tv/src/main/res/values-pt-rBR/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Escaneie o código QR ou abra o link acima</string>
     <string name="tv_receive_btn_disconnect">Desconectar</string>
     <string name="tv_receive_step3">Pronto para instalar</string>
+    <string name="tv_shizuku_missing">Shizuku não instalado</string>
+    <string name="tv_shizuku_stopped">Shizuku instalado, mas não em execução</string>
+    <string name="tv_shizuku_unsupported">Versão do Shizuku muito antiga (anterior à v11)</string>
+    <string name="tv_shizuku_permission">Toque para conceder permissão ao Shizuku</string>
+    <string name="tv_shizuku_ready">Instalação silenciosa sem avisos</string>
+    <string name="tv_shizuku_denied">Permissão do Shizuku negada</string>
+    <string name="tv_shizuku_on">Ativado — preferir Shizuku para instalação silenciosa</string>
+    <string name="tv_shizuku_off">Desativado — selecione para ativar o Shizuku</string>
+    <string name="tv_shizuku_error">Não foi possível solicitar permissão. Abra o Shizuku e tente novamente.</string>
 </resources>

--- a/tv/src/main/res/values-ro/strings.xml
+++ b/tv/src/main/res/values-ro/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: Scanați codul QR sau deschideți linkul de mai sus</string>
     <string name="tv_receive_btn_disconnect">Deconectare</string>
     <string name="tv_receive_step3">Gata de instalare</string>
+    <string name="tv_shizuku_missing">Shizuku nu este instalat</string>
+    <string name="tv_shizuku_stopped">Shizuku este instalat dar nu rulează</string>
+    <string name="tv_shizuku_unsupported">Versiunea Shizuku este prea veche (pre-v11)</string>
+    <string name="tv_shizuku_permission">Atinge pentru a acorda permisiunea Shizuku</string>
+    <string name="tv_shizuku_ready">Instalare silențioasă fără confirmări</string>
+    <string name="tv_shizuku_denied">Permisiunea Shizuku a fost refuzată</string>
+    <string name="tv_shizuku_on">Activat — preferă Shizuku pentru instalare silențioasă</string>
+    <string name="tv_shizuku_off">Dezactivat — selectează pentru a activa Shizuku</string>
+    <string name="tv_shizuku_error">Nu s-a putut solicita permisiunea. Deschide Shizuku și încearcă din nou.</string>
 </resources>

--- a/tv/src/main/res/values-ru/strings.xml
+++ b/tv/src/main/res/values-ru/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / ПК: отсканируйте QR-код или откройте ссылку выше</string>
     <string name="tv_receive_btn_disconnect">Отключить</string>
     <string name="tv_receive_step3">Готово к установке</string>
+    <string name="tv_shizuku_missing">Shizuku не установлен</string>
+    <string name="tv_shizuku_stopped">Shizuku установлен, но не запущен</string>
+    <string name="tv_shizuku_unsupported">Версия Shizuku слишком старая (до v11)</string>
+    <string name="tv_shizuku_permission">Нажмите, чтобы предоставить разрешение Shizuku</string>
+    <string name="tv_shizuku_ready">Тихая установка без подтверждений</string>
+    <string name="tv_shizuku_denied">В разрешении Shizuku отказано</string>
+    <string name="tv_shizuku_on">Включено — предпочитать тихую установку через Shizuku</string>
+    <string name="tv_shizuku_off">Выключено — выберите, чтобы включить Shizuku</string>
+    <string name="tv_shizuku_error">Не удалось запросить разрешение. Откройте Shizuku и повторите попытку.</string>
 </resources>

--- a/tv/src/main/res/values-tr/strings.xml
+++ b/tv/src/main/res/values-tr/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / PC: QR kodunu tarayın veya yukarıdaki bağlantıyı açın</string>
     <string name="tv_receive_btn_disconnect">Bağlantıyı Kes</string>
     <string name="tv_receive_step3">Yüklemeye hazır</string>
+    <string name="tv_shizuku_missing">Shizuku yüklü değil</string>
+    <string name="tv_shizuku_stopped">Shizuku yüklü ama çalışmıyor</string>
+    <string name="tv_shizuku_unsupported">Shizuku sürümü çok eski (v11 öncesi)</string>
+    <string name="tv_shizuku_permission">Shizuku izni vermek için dokunun</string>
+    <string name="tv_shizuku_ready">Onay istemeden sessiz yükleme</string>
+    <string name="tv_shizuku_denied">Shizuku izni reddedildi</string>
+    <string name="tv_shizuku_on">Açık — sessiz kurulum için Shizuku tercih edilir</string>
+    <string name="tv_shizuku_off">Kapalı — Shizuku uygulamasını etkinleştirmek için seçin</string>
+    <string name="tv_shizuku_error">İzin istenemedi. Shizuku uygulamasını açıp yeniden deneyin.</string>
 </resources>

--- a/tv/src/main/res/values-uk/strings.xml
+++ b/tv/src/main/res/values-uk/strings.xml
@@ -90,5 +90,14 @@
     <string name="tv_receive_step_web">🌐 iPhone / ПК: відскануйте QR-код або відкрийте посилання вище</string>
     <string name="tv_receive_btn_disconnect">Від\'єднати</string>
     <string name="tv_receive_step3">Готово до встановлення</string>
+    <string name="tv_shizuku_missing">Shizuku не встановлено</string>
+    <string name="tv_shizuku_stopped">Shizuku встановлено, але не працює</string>
+    <string name="tv_shizuku_unsupported">Версія Shizuku занадто стара (до v11)</string>
+    <string name="tv_shizuku_permission">Торкніться, щоб надати дозвіл Shizuku</string>
+    <string name="tv_shizuku_ready">Тихе встановлення без підказок</string>
+    <string name="tv_shizuku_denied">Доступ до Shizuku було відхилено</string>
+    <string name="tv_shizuku_on">Увімкнено — надавати перевагу тихому встановленню через Shizuku</string>
+    <string name="tv_shizuku_off">Вимкнено — виберіть, щоб увімкнути Shizuku</string>
+    <string name="tv_shizuku_error">Не вдалося запросити дозвіл. Відкрийте Shizuku та спробуйте ще раз.</string>
 </resources>
     

--- a/tv/src/main/res/values-vi/strings.xml
+++ b/tv/src/main/res/values-vi/strings.xml
@@ -91,4 +91,13 @@
     <string name="tv_manage_no_matches">Không tìm thấy kết quả cho \"%s\"</string>
     <string name="tv_manage_clear_search">Xóa tìm kiếm</string>
     <string name="tv_language_title">Ngôn ngữ</string>
+    <string name="tv_shizuku_on">Bật — ưu tiên Shizuku để cài đặt im lặng</string>
+    <string name="tv_shizuku_off">Tắt — chọn để bật Shizuku</string>
+    <string name="tv_shizuku_missing">Cài Shizuku trên TV rồi khởi động dịch vụ.</string>
+    <string name="tv_shizuku_stopped">Shizuku chưa chạy. Khởi động dịch vụ rồi quay lại đây.</string>
+    <string name="tv_shizuku_unsupported">Phiên bản Shizuku quá cũ. Hãy cập nhật lên phiên bản 11 trở lên.</string>
+    <string name="tv_shizuku_permission">Chọn để cấp quyền Shizuku.</string>
+    <string name="tv_shizuku_ready">Sẵn sàng cài APK và gói APK phân tách im lặng.</string>
+    <string name="tv_shizuku_denied">Quyền bị từ chối. Cho phép ứng dụng này trong Shizuku rồi thử lại.</string>
+    <string name="tv_shizuku_error">Không thể yêu cầu quyền. Mở Shizuku rồi thử lại.</string>
 </resources>

--- a/tv/src/main/res/values-zh/strings.xml
+++ b/tv/src/main/res/values-zh/strings.xml
@@ -90,4 +90,13 @@
     <string name="tv_receive_step_web">🌐 iPhone / 电脑: 扫码或在浏览器打开上方链接</string>
     <string name="tv_receive_btn_disconnect">断开连接</string>
     <string name="tv_receive_step3">准备安装</string>
+    <string name="tv_shizuku_missing">未安装 Shizuku</string>
+    <string name="tv_shizuku_stopped">Shizuku 已安装但未运行</string>
+    <string name="tv_shizuku_unsupported">Shizuku 版本过旧（低于 v11）</string>
+    <string name="tv_shizuku_permission">点击授予 Shizuku 权限</string>
+    <string name="tv_shizuku_ready">无弹窗静默安装</string>
+    <string name="tv_shizuku_denied">Shizuku 权限被拒绝</string>
+    <string name="tv_shizuku_on">已开启 — 优先通过 Shizuku 静默安装</string>
+    <string name="tv_shizuku_off">已关闭 — 选择以启用 Shizuku</string>
+    <string name="tv_shizuku_error">无法请求权限。请打开 Shizuku 后重试。</string>
 </resources>

--- a/tv/src/main/res/values/strings.xml
+++ b/tv/src/main/res/values/strings.xml
@@ -104,4 +104,14 @@
     <string name="tv_manage_status_disabled">Disabled</string>
     <string name="tv_manage_extracted_success">Extracted ✓</string>
     <string name="tv_manage_extract_error_prefix">Error: %s</string>
+    <string name="tv_shizuku_title" translatable="false">Shizuku</string>
+    <string name="tv_shizuku_on">On — prefer Shizuku for silent installation</string>
+    <string name="tv_shizuku_off">Off — select to enable Shizuku</string>
+    <string name="tv_shizuku_missing">Install Shizuku on your TV, then start its service.</string>
+    <string name="tv_shizuku_stopped">Shizuku is not running. Start its service and return here.</string>
+    <string name="tv_shizuku_unsupported">This Shizuku version is too old. Update to version 11 or newer.</string>
+    <string name="tv_shizuku_permission">Select to grant Shizuku permission.</string>
+    <string name="tv_shizuku_ready">Ready for silent APK and split-bundle installation.</string>
+    <string name="tv_shizuku_denied">Permission denied. Allow this app in Shizuku, then try again.</string>
+    <string name="tv_shizuku_error">Could not request permission. Open Shizuku and try again.</string>
 </resources>

--- a/tv/src/test/java/app/pwhs/tv/install/TvInstallBackendTest.kt
+++ b/tv/src/test/java/app/pwhs/tv/install/TvInstallBackendTest.kt
@@ -1,0 +1,27 @@
+package app.pwhs.tv.install
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TvInstallBackendTest {
+    @Test fun readyShizukuDoesNotTriggerRootPrompt() = runBlocking {
+        assertEquals(TvInstallBackend.Shizuku, TvInstallBackend.select(true, true,
+            shizukuReady = { true }, rootReady = { error("Must not request root") }))
+    }
+
+    @Test fun stoppedOrRevokedShizukuFallsBackToRoot() = runBlocking {
+        assertEquals(TvInstallBackend.Root, TvInstallBackend.select(true, true,
+            shizukuReady = { false }, rootReady = { true }))
+    }
+
+    @Test fun unavailablePrivilegesUseSystemInstaller() = runBlocking {
+        assertEquals(TvInstallBackend.System, TvInstallBackend.select(true, true,
+            shizukuReady = { false }, rootReady = { false }))
+    }
+
+    @Test fun disabledBackendsAreNotProbed() = runBlocking {
+        assertEquals(TvInstallBackend.System, TvInstallBackend.select(false, false,
+            shizukuReady = { error("Shizuku disabled") }, rootReady = { error("Root disabled") }))
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Shizuku support for silent APK installation on TV devices.
  - Added settings for Shizuku availability, permissions, and readiness.
  - Added configurable installation options for replacing, downgrading, granting permissions, test packages, and all-user installs.
  - Installations select the best available method, falling back to root or the system installer.
  - Added standalone and split APK installation with progress reporting.
- **Localization**
  - Added Shizuku status, permission, and error messages across supported languages.
- **Tests**
  - Added coverage for installation-method selection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->