### PR TITLE
feat(installer): Custom Authorizer support, ModalBottomSheet UI & 18-locale i18n

### DIFF
--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/composable/InstallerModeBadge.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/composable/InstallerModeBadge.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.rounded.AdminPanelSettings
 import androidx.compose.material.icons.rounded.Android
 import androidx.compose.material.icons.rounded.Key
 import androidx.compose.material.icons.rounded.Shield
+import androidx.compose.material.icons.rounded.Terminal
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +61,7 @@ fun InstallerModeBadge(modifier: Modifier = Modifier) {
     val modeFlow = remember(context) {
         context.dataStore.data.map { prefs ->
             when {
+                prefs[PreferencesKeys.USE_CUSTOM_AUTHORIZER] == true -> Mode.Custom
                 prefs[PreferencesKeys.USE_ROOT] == true -> Mode.Root
                 prefs[PreferencesKeys.USE_SHIZUKU] == true -> Mode.Shizuku
                 prefs[PreferencesKeys.USE_DHIZUKU] == true -> Mode.Dhizuku
@@ -79,18 +81,20 @@ fun InstallerModeBadge(modifier: Modifier = Modifier) {
     }
 
     val label = when (mode) {
+        Mode.Custom -> stringResource(R.string.installer_mode_custom)
         Mode.Root -> stringResource(R.string.installer_mode_root)
         Mode.Shizuku -> stringResource(R.string.installer_mode_shizuku)
         Mode.Dhizuku -> stringResource(R.string.installer_mode_dhizuku)
         Mode.Default -> stringResource(R.string.installer_mode_package_installer)
     }
     val icon = when (mode) {
+        Mode.Custom -> Icons.Rounded.Terminal
         Mode.Root -> Icons.Rounded.Key
         Mode.Shizuku -> Icons.Rounded.AdminPanelSettings
         Mode.Dhizuku -> Icons.Rounded.Shield
         Mode.Default -> Icons.Rounded.Android
     }
-    val privileged = mode == Mode.Root || mode == Mode.Shizuku || mode == Mode.Dhizuku
+    val privileged = mode == Mode.Root || mode == Mode.Shizuku || mode == Mode.Dhizuku || mode == Mode.Custom
     val container = if (privileged)
         MaterialTheme.colorScheme.primaryContainer
     else
@@ -128,6 +132,7 @@ fun InstallerModeBadge(modifier: Modifier = Modifier) {
             useShizuku = mode == Mode.Shizuku,
             useRoot = mode == Mode.Root,
             useDhizuku = mode == Mode.Dhizuku,
+            useCustomAuthorizer = mode == Mode.Custom,
         )
         // Root stays tappable whenever this build ships su support — tapping it when not yet
         // ready fires the root request (su prompt). It's only greyed (dimmed) to signal it
@@ -222,6 +227,16 @@ fun InstallerModeBadge(modifier: Modifier = Modifier) {
                             showPicker = false
                         },
                     )
+                    EngineOption(
+                        title = stringResource(R.string.installer_mode_custom),
+                        subtitle = stringResource(R.string.installer_engine_custom_desc),
+                        selected = current == InstallMode.CUSTOM,
+                        enabled = true,
+                        onClick = {
+                            settingViewModel.setInstallMode(InstallMode.CUSTOM)
+                            showPicker = false
+                        },
+                    )
                 }
             },
             confirmButton = {
@@ -264,4 +279,4 @@ private fun EngineOption(
     }
 }
 
-private enum class Mode { Default, Shizuku, Dhizuku, Root }
+private enum class Mode { Default, Shizuku, Dhizuku, Root, Custom }

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/InstallViewModel.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/InstallViewModel.kt
@@ -18,6 +18,7 @@ import app.pwhs.universalinstaller.domain.manager.InstallBlacklist
 import app.pwhs.universalinstaller.domain.model.InstallerProfile
 import app.pwhs.universalinstaller.domain.repository.SessionDataRepository
 import app.pwhs.universalinstaller.presentation.install.controller.BaseInstallController
+import app.pwhs.universalinstaller.presentation.install.controller.CustomInstallController
 import app.pwhs.universalinstaller.presentation.install.controller.DefaultInstallController
 import app.pwhs.universalinstaller.presentation.install.controller.DhizukuInstallController
 import app.pwhs.universalinstaller.presentation.install.controller.InstallerBackendFactory
@@ -83,6 +84,9 @@ class InstallViewModel(
         else DhizukuInstallController(application, packageInstaller, sessionDataRepository, historyDao)
     }
     private val rootController: BaseInstallController? = backendFactory.createRootController(
+        application, packageInstaller, sessionDataRepository, historyDao,
+    )
+    private val customController = CustomInstallController(
         application, packageInstaller, sessionDataRepository, historyDao,
     )
 
@@ -170,6 +174,7 @@ class InstallViewModel(
             shizukuController = shizukuController,
             rootController = rootController,
             dhizukuController = dhizukuController,
+            customController = customController,
             backendFactory = backendFactory,
         )
 
@@ -471,6 +476,7 @@ class InstallViewModel(
             shizukuController = shizukuController,
             rootController = rootController,
             dhizukuController = dhizukuController,
+            customController = customController,
             backendFactory = backendFactory,
             packageUninstaller = packageUninstaller,
         )

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/CustomInstallController.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/CustomInstallController.kt
@@ -1,0 +1,117 @@
+package app.pwhs.universalinstaller.presentation.install.controller
+
+import android.app.Application
+import android.content.Context
+import android.net.Uri
+import app.pwhs.core.data.local.dataStore
+import app.pwhs.universalinstaller.data.local.InstallHistoryDao
+import app.pwhs.universalinstaller.domain.model.SessionData
+import app.pwhs.universalinstaller.domain.repository.SessionDataRepository
+import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
+import app.pwhs.universalinstaller.telemetry.TelemetryEvents
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import ru.solrudev.ackpine.installer.InstallFailure
+import ru.solrudev.ackpine.installer.PackageInstaller
+import ru.solrudev.ackpine.resources.ResolvableString
+import ru.solrudev.ackpine.session.Progress
+import ru.solrudev.ackpine.session.ProgressSession
+import timber.log.Timber
+import java.util.UUID
+
+/**
+ * Installer controller powered by a custom shell/authorizer command template.
+ *
+ * Runs `pm install-create/write/commit` commands through [CustomTargetedInstaller],
+ * updating UI progress, install history, and telemetry identically to [RootInstallController].
+ */
+class CustomInstallController(
+    private val application: Application,
+    packageInstaller: PackageInstaller,
+    sessionDataRepository: SessionDataRepository,
+    historyDao: InstallHistoryDao,
+) : BaseInstallController(application, packageInstaller, sessionDataRepository, historyDao) {
+
+    override val telemetryMethod = "custom"
+
+    override fun install(
+        uris: List<Uri>,
+        sessionData: SessionData,
+        scope: CoroutineScope,
+        context: Context?,
+        originalUri: Uri?,
+        deleteAfterInstall: Boolean,
+        allowDowngrade: Boolean,
+        onSuccess: (suspend () -> Unit)?,
+        onSessionCreated: ((UUID) -> Unit)?,
+    ) {
+        val sessionId = UUID.randomUUID()
+        val data = sessionData.copy(
+            id = sessionId,
+            uris = uris,
+            originalUri = originalUri,
+            deleteAfterInstall = deleteAfterInstall,
+            allowDowngrade = allowDowngrade,
+        )
+        scope.launch {
+            sessionDataRepository.addSessionData(data)
+            onSessionCreated?.invoke(sessionId)
+            reportInstallStarted(uris.size)
+
+            val onProgress: (Float) -> Unit = { fraction ->
+                sessionDataRepository.updateSessionProgress(
+                    sessionId,
+                    Progress((fraction * 100).toInt().coerceIn(0, 100), 100),
+                )
+            }
+
+            val prefs = runCatching { application.dataStore.data.first() }.getOrNull()
+            val userId = if (prefs?.get(PreferencesKeys.ROOT_ALL_USERS) == true) -1
+            else android.os.Process.myUid() / 100000
+
+            val result = CustomTargetedInstaller.install(
+                context = application,
+                uris = uris,
+                userId = userId,
+                packageName = sessionData.packageName,
+                allowDowngrade = allowDowngrade,
+                onProgress = onProgress,
+            )
+
+            result.fold(
+                onSuccess = {
+                    sessionDataRepository.updateSessionProgress(sessionId, Progress(100, 100))
+                    reportInstallResult(TelemetryEvents.RESULT_SUCCESS)
+                    saveHistory(data, success = true)
+                    runCatching { onSuccess?.invoke() }
+                        .onFailure { Timber.e(it, "Install success hook failed") }
+                    if (deleteAfterInstall && originalUri != null) {
+                        deleteSourceFileAndWarn(context ?: application, originalUri)
+                    }
+                    autoOpenAppIfNeeded(data.packageName, context ?: application)
+                    sessionDataRepository.removeSessionData(sessionId)
+                },
+                onFailure = { e ->
+                    Timber.e(e, "Custom shell install failed")
+                    reportInstallResult(TelemetryEvents.RESULT_FAILURE)
+                    saveHistory(data, success = false, errorMessage = e.message)
+                    sessionDataRepository.setError(
+                        sessionId,
+                        ResolvableString.raw(e.message ?: "Installation failed"),
+                    )
+                },
+            )
+        }
+    }
+
+    override suspend fun createSession(
+        uris: List<Uri>,
+        name: String,
+        packageName: String,
+        allowDowngrade: Boolean,
+        targetUserId: Int?,
+    ): ProgressSession<InstallFailure> {
+        throw UnsupportedOperationException("CustomInstallController drives installs via CustomTargetedInstaller")
+    }
+}

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/CustomTargetedInstaller.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/controller/CustomTargetedInstaller.kt
@@ -1,0 +1,154 @@
+package app.pwhs.universalinstaller.presentation.install.controller
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import app.pwhs.core.data.local.dataStore
+import app.pwhs.universalinstaller.presentation.install.dialog.InstallerOverrides
+import app.pwhs.universalinstaller.presentation.setting.DEFAULT_INSTALLER_PACKAGE_NAME
+import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
+import app.pwhs.universalinstaller.util.CustomShellExecutor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.util.UUID
+
+/**
+ * Installs APKs via custom shell/authorizer commands (`pm install-create/write/commit`).
+ *
+ * Counterpart of [RootTargetedInstaller] which routes through libsu Shell;
+ * CustomTargetedInstaller routes through [CustomShellExecutor].
+ */
+object CustomTargetedInstaller {
+
+    suspend fun install(
+        context: Context,
+        uris: List<Uri>,
+        userId: Int,
+        packageName: String = "",
+        allowDowngrade: Boolean = false,
+        onProgress: (Float) -> Unit = {},
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val createArgs = buildCreateArgs(context, packageName, allowDowngrade)
+            val stagingDir = File(context.cacheDir, "custom_install_${UUID.randomUUID()}").apply {
+                mkdirs()
+            }
+            val stagedFiles = try {
+                uris.mapIndexed { idx, uri ->
+                    val out = File(stagingDir, "split_$idx.apk")
+                    context.contentResolver.openInputStream(uri).use { input ->
+                        requireNotNull(input) { "Failed to open URI $uri" }
+                        out.outputStream().use { input.copyTo(it) }
+                    }
+                    out.setReadable(true, false)
+                    out
+                }.also {
+                    stagingDir.setReadable(true, false)
+                    stagingDir.setExecutable(true, false)
+                }
+            } catch (e: Exception) {
+                stagingDir.deleteRecursively()
+                throw e
+            }
+
+            try {
+                val sessionId = createSession(context, userId, createArgs)
+                onProgress(0.1f)
+
+                stagedFiles.forEachIndexed { idx, file ->
+                    writeSplit(context, sessionId, idx, file)
+                    onProgress(0.1f + 0.8f * ((idx + 1).toFloat() / stagedFiles.size))
+                }
+
+                commitSession(context, sessionId)
+                onProgress(1f)
+            } finally {
+                stagingDir.deleteRecursively()
+            }
+        }
+    }
+
+    private suspend fun buildCreateArgs(
+        context: Context,
+        packageName: String,
+        allowDowngrade: Boolean,
+    ): List<String> {
+        val prefs = runCatching { context.dataStore.data.first() }.getOrNull()
+        val args = mutableListOf<String>()
+        if (prefs?.get(PreferencesKeys.ROOT_REPLACE_EXISTING) != false) args += "-r"
+        if (allowDowngrade || prefs?.get(PreferencesKeys.ROOT_REQUEST_DOWNGRADE) == true) args += "-d"
+        if (prefs?.get(PreferencesKeys.ROOT_ALLOW_TEST) == true) args += "-t"
+        if (prefs?.get(PreferencesKeys.ROOT_GRANT_ALL_PERMISSIONS) == true) args += "-g"
+        if (prefs?.get(PreferencesKeys.ROOT_BYPASS_LOW_TARGET_SDK) == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) args += "--bypass-low-target-sdk-block"
+        if (prefs?.get(PreferencesKeys.ROOT_DONT_KILL_APP) == true) args += "--dont-kill"
+        if (prefs?.get(PreferencesKeys.ROOT_DISABLE_VERIFICATION) == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        ) args += "--skip-verification"
+        if (prefs?.get(PreferencesKeys.ROOT_ENABLE_ROLLBACK) == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        ) args += "--enable-rollback"
+        if (prefs?.get(PreferencesKeys.ROOT_REQUEST_UPDATE_OWNERSHIP) == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+        ) args += "--update-ownership"
+        if (prefs?.get(PreferencesKeys.ROOT_SET_INSTALL_SOURCE) == true) {
+            val override = if (packageName.isNotBlank()) {
+                InstallerOverrides.get(prefs[PreferencesKeys.INSTALLER_OVERRIDES], packageName)
+            } else null
+            val installer = override
+                ?: prefs[PreferencesKeys.ROOT_INSTALLER_PACKAGE_NAME]?.trim()?.ifBlank { DEFAULT_INSTALLER_PACKAGE_NAME }
+                ?: DEFAULT_INSTALLER_PACKAGE_NAME
+            if (installer.isNotBlank()) args += "-i $installer"
+        }
+        return args
+    }
+
+    private suspend fun createSession(context: Context, userId: Int, createArgs: List<String>): String {
+        val userArg = if (userId >= 0) "--user $userId " else ""
+        val flags = createArgs.joinToString(" ")
+        val result = CustomShellExecutor.exec(context, "pm install-create $userArg$flags".trim())
+        if (!result.isSuccess) {
+            throw RuntimeException("pm install-create failed: ${joinErr(result)}")
+        }
+        val line = result.out.joinToString("\n")
+        val sessionId = extractSessionId(line)
+            ?: throw RuntimeException("Could not parse session id from: $line")
+        Timber.d("CustomTargetedInstaller: created session=$sessionId user=$userId")
+        return sessionId
+    }
+
+    private suspend fun writeSplit(context: Context, sessionId: String, index: Int, file: File) {
+        val size = file.length()
+        val splitName = "split_$index"
+        val pathArg = file.absolutePath.replace(" ", "\\ ")
+        val cmd = "pm install-write -S $size $sessionId $splitName $pathArg"
+        var result = CustomShellExecutor.exec(context, cmd)
+        if (!result.isSuccess) {
+            val pipeCmd = "cat ${file.absolutePath.replace(" ", "\\ ")} | pm install-write -S $size $sessionId $splitName -"
+            result = CustomShellExecutor.exec(context, pipeCmd)
+            if (!result.isSuccess) {
+                throw RuntimeException("pm install-write failed for split_$index: ${joinErr(result)}")
+            }
+        }
+    }
+
+    private suspend fun commitSession(context: Context, sessionId: String) {
+        val result = CustomShellExecutor.exec(context, "pm install-commit $sessionId")
+        val stdout = result.out.joinToString("\n")
+        if (!result.isSuccess || !stdout.contains("Success", ignoreCase = true)) {
+            throw RuntimeException(stdout.ifBlank { joinErr(result) }.ifBlank { "install-commit failed" })
+        }
+    }
+
+    private fun extractSessionId(text: String): String? {
+        val regex = Regex("""session\s*\[(\d+)]""", RegexOption.IGNORE_CASE)
+        return regex.find(text)?.groupValues?.getOrNull(1)
+    }
+
+    private fun joinErr(result: CustomShellExecutor.Result): String =
+        result.err.joinToString("\n").ifBlank { result.out.joinToString("\n") }
+}

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/install/util/InstallSessionManager.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/install/util/InstallSessionManager.kt
@@ -19,6 +19,7 @@ import app.pwhs.universalinstaller.presentation.install.controller.ManualInstall
 import app.pwhs.universalinstaller.presentation.install.controller.RootState
 import app.pwhs.universalinstaller.presentation.install.controller.ShizukuInstallController
 import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
+import app.pwhs.universalinstaller.util.CustomShellExecutor
 import app.pwhs.universalinstaller.util.DhizukuCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -41,6 +42,7 @@ object InstallSessionManager {
         shizukuController: ShizukuInstallController,
         rootController: BaseInstallController?,
         dhizukuController: BaseInstallController?,
+        customController: BaseInstallController? = null,
         backendFactory: InstallerBackendFactory,
     ): BaseInstallController {
         val prefs = try { context.dataStore.data.first() } catch (_: Exception) { null }
@@ -50,6 +52,7 @@ object InstallSessionManager {
         val preferredBackend = profile?.preferredBackend
         if (preferredBackend != null) {
             when (preferredBackend) {
+                "Custom" -> customController?.let { return it }
                 "Root" -> if (rootController != null) {
                     val state = backendFactory.probeRootState()
                     val finalState = if (state == RootState.READY) state
@@ -63,6 +66,11 @@ object InstallSessionManager {
                 }
                 "Default" -> return defaultController
             }
+        }
+
+        val useCustomAuthorizer = prefs?.get(PreferencesKeys.USE_CUSTOM_AUTHORIZER) ?: false
+        if (useCustomAuthorizer && customController != null) {
+            return customController
         }
 
         val useRoot = prefs?.get(PreferencesKeys.USE_ROOT) ?: false
@@ -140,20 +148,41 @@ object InstallSessionManager {
         shizukuController: ShizukuInstallController,
         rootController: BaseInstallController?,
         dhizukuController: BaseInstallController?,
+        customController: BaseInstallController? = null,
         backendFactory: InstallerBackendFactory,
         packageUninstaller: PackageUninstaller,
     ): Boolean {
         if (packageName.isBlank()) return false
         val controller = runCatching {
             activeController(
-                context, profileId, defaultController, shizukuController, rootController, dhizukuController, backendFactory
+                context = context,
+                profileId = profileId,
+                defaultController = defaultController,
+                shizukuController = shizukuController,
+                rootController = rootController,
+                dhizukuController = dhizukuController,
+                customController = customController,
+                backendFactory = backendFactory,
             )
         }.getOrNull()
 
         return when {
+            customController != null && controller === customController -> uninstallViaCustom(context, packageName)
             controller === shizukuController -> uninstallViaShizuku(packageName, packageUninstaller)
             rootController != null && controller === rootController -> uninstallViaRoot(packageName)
             else -> false
+        }
+    }
+
+    private suspend fun uninstallViaCustom(
+        context: Context,
+        packageName: String,
+    ): Boolean = withContext(Dispatchers.IO) {
+        try {
+            CustomShellExecutor.exec(context, "pm uninstall $packageName").isSuccess
+        } catch (e: Exception) {
+            Timber.e(e, "Custom authorizer uninstall of $packageName failed")
+            false
         }
     }
 

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/PreferencesKeys.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/PreferencesKeys.kt
@@ -51,6 +51,9 @@ object PreferencesKeys {
     val SHIZUKU_REQUEST_DOWNGRADE = booleanPreferencesKey("shizuku_request_downgrade")
     val USE_DHIZUKU = booleanPreferencesKey("use_dhizuku")
     val DHIZUKU_REQUEST_DOWNGRADE = booleanPreferencesKey("dhizuku_request_downgrade")
+    val USE_CUSTOM_AUTHORIZER = booleanPreferencesKey("use_custom_authorizer")
+    val CUSTOM_AUTHORIZER_COMMAND = stringPreferencesKey("custom_authorizer_command")
+    const val DEFAULT_CUSTOM_AUTHORIZER_COMMAND = "su -c {command}"
     val SHIZUKU_GRANT_ALL_PERMISSIONS = booleanPreferencesKey("shizuku_grant_all_permissions")
     val SHIZUKU_ALL_USERS = booleanPreferencesKey("shizuku_all_users")
     val SHIZUKU_SET_INSTALL_SOURCE = booleanPreferencesKey("shizuku_set_install_source")

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingModels.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingModels.kt
@@ -83,10 +83,17 @@ enum class InstallMode {
     DEFAULT,
     SHIZUKU,
     DHIZUKU,
-    ROOT;
+    ROOT,
+    CUSTOM;
 
     companion object {
-        fun from(useShizuku: Boolean, useRoot: Boolean, useDhizuku: Boolean = false): InstallMode = when {
+        fun from(
+            useShizuku: Boolean,
+            useRoot: Boolean,
+            useDhizuku: Boolean = false,
+            useCustomAuthorizer: Boolean = false,
+        ): InstallMode = when {
+            useCustomAuthorizer -> CUSTOM
             useDhizuku -> DHIZUKU
             useRoot -> ROOT
             useShizuku -> SHIZUKU
@@ -169,6 +176,8 @@ data class SettingUiState(
     val appProfileMapping: Map<String, String> = emptyMap(),
     val isDefaultInstaller: Boolean = false,
     val selectedLanguage: String = "",
+    val useCustomAuthorizer: Boolean = false,
+    val customAuthorizerCommand: String = "",
     /**
      * True when the device has at least one biometric or device-credential enrolled.
      * Used to inform the user that the toggles will be no-ops until they

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingScreen.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingScreen.kt
@@ -123,6 +123,8 @@ fun SettingScreen(
         onUseDhizukuChanged = viewModel::setUseDhizuku,
         onPrivilegedOptionChanged = viewModel::setPrivilegedOption,
         onInstallerPackageChanged = viewModel::setInstallerPackageName,
+        onCustomAuthorizerCommandChange = viewModel::setCustomAuthorizerCommand,
+        onTestCustomAuthorizerCommand = viewModel::testCustomAuthorizerCommand,
         blacklist = blacklist,
         onReplayTutorial = {
             // Reuse MainActivity's onboarding route rather than clearing ONBOARDING_COMPLETED:
@@ -187,6 +189,8 @@ private fun SettingUi(
     onShizukuInstallerChanged: (String) -> Unit = {},
     onDeleteApkChanged: (Boolean) -> Unit = {},
     onAutoOpenAfterInstallChanged: (Boolean) -> Unit = {},
+    onCustomAuthorizerCommandChange: (String) -> Unit = {},
+    onTestCustomAuthorizerCommand: suspend (String) -> Result<String> = { Result.success("") },
     onLanguageClick: () -> Unit = {},
     onRootRetry: () -> Unit = {},
     onRootOptionChanged: (Preferences.Key<Boolean>, Boolean) -> Unit = { _, _ -> },
@@ -361,7 +365,9 @@ private fun SettingUi(
                     onRootRetry = onRootRetry,
                     onDeleteApkChanged = onDeleteApkChanged,
                     onAutoOpenAfterInstallChanged = onAutoOpenAfterInstallChanged,
-                    onDefaultInstallerChanged = onDefaultInstallerChanged
+                    onDefaultInstallerChanged = onDefaultInstallerChanged,
+                    onCustomAuthorizerCommandChange = onCustomAuthorizerCommandChange,
+                    onTestCustomAuthorizerCommand = onTestCustomAuthorizerCommand,
                 )
 
                 // ── Install options ──────────────────────────

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingViewModel.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/SettingViewModel.kt
@@ -15,6 +15,7 @@ import app.pwhs.universalinstaller.presentation.setting.util.SettingPreferencesD
 import app.pwhs.universalinstaller.presentation.setting.util.SettingPrivilegeDelegate
 import app.pwhs.universalinstaller.presentation.setting.util.SettingProfilesDelegate
 import app.pwhs.universalinstaller.presentation.setting.util.SettingUiStateBuilder
+import app.pwhs.universalinstaller.util.CustomShellExecutor
 import app.pwhs.universalinstaller.util.DhizukuState
 import app.pwhs.universalinstaller.util.LocaleHelper
 import kotlinx.coroutines.channels.Channel
@@ -217,6 +218,8 @@ class SettingViewModel(
         },
         _selectedLanguage,
         privilegeDelegate.isDefaultInstaller,
+        privilegeDelegate.useCustomAuthorizer,
+        privilegeDelegate.customAuthorizerCommand,
     ) { flows ->
         SettingUiStateBuilder.build(application, backendFactory, flows)
     }.stateIn(
@@ -248,6 +251,11 @@ class SettingViewModel(
     fun setPrivilegedOption(option: PrivilegedOption, enabled: Boolean) = privilegeDelegate.setPrivilegedOption(option, enabled)
     fun setInstallerPackageName(packageName: String) = privilegeDelegate.setInstallerPackageName(packageName)
     fun toggleDefaultInstaller(enabled: Boolean) = privilegeDelegate.toggleDefaultInstaller(enabled)
+    val useCustomAuthorizer: StateFlow<Boolean> = privilegeDelegate.useCustomAuthorizer
+    val customAuthorizerCommand: StateFlow<String> = privilegeDelegate.customAuthorizerCommand
+    fun setCustomAuthorizerCommand(command: String) = privilegeDelegate.setCustomAuthorizerCommand(command)
+    suspend fun testCustomAuthorizerCommand(command: String): Result<String> =
+        CustomShellExecutor.testCommand(command)
 
     // ── Preferences Delegates ───────────────────────────────────────────────
 

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
@@ -1,0 +1,169 @@
+package app.pwhs.universalinstaller.presentation.setting.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Terminal
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import app.pwhs.universalinstaller.R
+import kotlinx.coroutines.launch
+
+@Composable
+fun CustomAuthorizerCard(
+    command: String,
+    onCommandChange: (String) -> Unit,
+    onTestCommand: suspend (String) -> Result<String>,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    var isTesting by remember { mutableStateOf(false) }
+    var testResult by remember { mutableStateOf<Result<String>?>(null) }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            OutlinedTextField(
+                value = command,
+                onValueChange = {
+                    onCommandChange(it)
+                    testResult = null
+                },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text(stringResource(R.string.setting_custom_authorizer_cmd_label)) },
+                placeholder = { Text(stringResource(R.string.setting_custom_authorizer_cmd_hint)) },
+                leadingIcon = {
+                    Icon(Icons.Rounded.Terminal, contentDescription = null)
+                },
+                supportingText = {
+                    Text(
+                        text = stringResource(R.string.setting_custom_authorizer_cmd_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                },
+                singleLine = false,
+                maxLines = 3,
+                textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                FilledTonalButton(
+                    onClick = {
+                        scope.launch {
+                            isTesting = true
+                            testResult = onTestCommand(command)
+                            isTesting = false
+                        }
+                    },
+                    enabled = !isTesting && command.isNotBlank(),
+                ) {
+                    if (isTesting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    } else {
+                        Icon(
+                            Icons.Rounded.PlayArrow,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                    Spacer(modifier = Modifier.size(ButtonDefaults.IconSpacing))
+                    Text(stringResource(R.string.setting_custom_authorizer_test))
+                }
+            }
+
+            AnimatedVisibility(visible = testResult != null) {
+                testResult?.let { res ->
+                    Spacer(modifier = Modifier.height(10.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (res.isSuccess) {
+                            Icon(
+                                Icons.Rounded.CheckCircle,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                text = stringResource(
+                                    R.string.setting_custom_authorizer_test_success,
+                                    res.getOrNull().orEmpty(),
+                                ),
+                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        } else {
+                            Icon(
+                                Icons.Rounded.ErrorOutline,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                text = stringResource(
+                                    R.string.setting_custom_authorizer_test_failed,
+                                    res.exceptionOrNull()?.message.orEmpty(),
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
@@ -35,6 +35,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.automirrored.rounded.RotateLeft
+import androidx.compose.material3.IconButton
+import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
+import app.pwhs.universalinstaller.util.CustomShellExecutor
 import app.pwhs.universalinstaller.R
 import kotlinx.coroutines.launch
 
@@ -48,6 +52,22 @@ fun CustomAuthorizerCard(
     val scope = rememberCoroutineScope()
     var isTesting by remember { mutableStateOf(false) }
     var testResult by remember { mutableStateOf<Result<String>?>(null) }
+
+    val validation = remember(command) { CustomShellExecutor.validateCommand(command) }
+    val isError = validation is CustomShellExecutor.ValidationResult.Error
+    val errorMessage = when (validation) {
+        is CustomShellExecutor.ValidationResult.Error -> when (validation.reason) {
+            CustomShellExecutor.ValidationErrorReason.BLANK ->
+                stringResource(R.string.setting_custom_authorizer_err_blank)
+            CustomShellExecutor.ValidationErrorReason.DANGEROUS_COMMAND ->
+                stringResource(R.string.setting_custom_authorizer_err_dangerous, validation.detail)
+            CustomShellExecutor.ValidationErrorReason.NOT_AUTHORIZER_BINARY ->
+                stringResource(R.string.setting_custom_authorizer_err_not_authorizer, validation.detail)
+            CustomShellExecutor.ValidationErrorReason.MISSING_PLACEHOLDER ->
+                stringResource(R.string.setting_custom_authorizer_err_missing_placeholder, validation.detail)
+        }
+        else -> null
+    }
 
     Card(
         modifier = modifier
@@ -70,16 +90,41 @@ fun CustomAuthorizerCard(
                     testResult = null
                 },
                 modifier = Modifier.fillMaxWidth(),
+                isError = isError,
                 label = { Text(stringResource(R.string.setting_custom_authorizer_cmd_label)) },
                 placeholder = { Text(stringResource(R.string.setting_custom_authorizer_cmd_hint)) },
                 leadingIcon = {
                     Icon(Icons.Rounded.Terminal, contentDescription = null)
                 },
+                trailingIcon = {
+                    if (command != PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND) {
+                        IconButton(
+                            onClick = {
+                                onCommandChange(PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND)
+                                testResult = null
+                            },
+                        ) {
+                            Icon(
+                                Icons.AutoMirrored.Rounded.RotateLeft,
+                                contentDescription = stringResource(R.string.setting_custom_authorizer_reset_default),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                },
                 supportingText = {
-                    Text(
-                        text = stringResource(R.string.setting_custom_authorizer_cmd_desc),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
+                    if (errorMessage != null) {
+                        Text(
+                            text = errorMessage,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.setting_custom_authorizer_cmd_desc),
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
                 },
                 singleLine = false,
                 maxLines = 3,
@@ -101,7 +146,7 @@ fun CustomAuthorizerCard(
                             isTesting = false
                         }
                     },
-                    enabled = !isTesting && command.isNotBlank(),
+                    enabled = !isTesting && !isError && command.isNotBlank(),
                 ) {
                     if (isTesting) {
                         CircularProgressIndicator(

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
@@ -10,7 +10,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.RotateLeft
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -21,25 +23,31 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.material.icons.automirrored.rounded.RotateLeft
-import androidx.compose.material3.IconButton
+import app.pwhs.universalinstaller.R
 import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
 import app.pwhs.universalinstaller.util.CustomShellExecutor
-import app.pwhs.universalinstaller.R
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -53,7 +61,36 @@ fun CustomAuthorizerCard(
     var isTesting by remember { mutableStateOf(false) }
     var testResult by remember { mutableStateOf<Result<String>?>(null) }
 
-    val validation = remember(command) { CustomShellExecutor.validateCommand(command) }
+    // Maintain local state so typing is immediate and smooth without async DataStore jitter/cursor jumps
+    var localCommand by rememberSaveable { mutableStateOf(command) }
+
+    // Sync from external state (e.g. initial load or reset from outside)
+    LaunchedEffect(command) {
+        if (command != localCommand) {
+            localCommand = command
+        }
+    }
+
+    // Debounce updates back to DataStore
+    LaunchedEffect(localCommand) {
+        if (localCommand != command) {
+            delay(300L)
+            onCommandChange(localCommand)
+        }
+    }
+
+    // Flush any pending changes when leaving composition
+    val currentLocalCommand by rememberUpdatedState(localCommand)
+    val currentExternalCommand by rememberUpdatedState(command)
+    DisposableEffect(Unit) {
+        onDispose {
+            if (currentLocalCommand != currentExternalCommand) {
+                onCommandChange(currentLocalCommand)
+            }
+        }
+    }
+
+    val validation = remember(localCommand) { CustomShellExecutor.validateCommand(localCommand) }
     val isError = validation is CustomShellExecutor.ValidationResult.Error
     val errorMessage = when (validation) {
         is CustomShellExecutor.ValidationResult.Error -> when (validation.reason) {
@@ -84,9 +121,9 @@ fun CustomAuthorizerCard(
                 .padding(16.dp),
         ) {
             OutlinedTextField(
-                value = command,
+                value = localCommand,
                 onValueChange = {
-                    onCommandChange(it)
+                    localCommand = it
                     testResult = null
                 },
                 modifier = Modifier.fillMaxWidth(),
@@ -97,9 +134,10 @@ fun CustomAuthorizerCard(
                     Icon(Icons.Rounded.Terminal, contentDescription = null)
                 },
                 trailingIcon = {
-                    if (command != PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND) {
+                    if (localCommand != PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND) {
                         IconButton(
                             onClick = {
+                                localCommand = PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND
                                 onCommandChange(PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND)
                                 testResult = null
                             },
@@ -128,6 +166,11 @@ fun CustomAuthorizerCard(
                 },
                 singleLine = false,
                 maxLines = 3,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrectEnabled = false,
+                    keyboardType = KeyboardType.Ascii,
+                ),
                 textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
             )
 
@@ -141,12 +184,15 @@ fun CustomAuthorizerCard(
                 FilledTonalButton(
                     onClick = {
                         scope.launch {
+                            if (localCommand != command) {
+                                onCommandChange(localCommand)
+                            }
                             isTesting = true
-                            testResult = onTestCommand(command)
+                            testResult = onTestCommand(localCommand)
                             isTesting = false
                         }
                     },
-                    enabled = !isTesting && !isError && command.isNotBlank(),
+                    enabled = !isTesting && !isError && localCommand.isNotBlank(),
                 ) {
                     if (isTesting) {
                         CircularProgressIndicator(

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/CustomAuthorizerCard.kt
@@ -1,55 +1,84 @@
 package app.pwhs.universalinstaller.presentation.setting.components
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.RotateLeft
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Terminal
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import app.pwhs.universalinstaller.R
 import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
 import app.pwhs.universalinstaller.util.CustomShellExecutor
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+private data class AuthorizerPreset(
+    val label: String,
+    val command: String,
+)
+
+private val PRESETS = listOf(
+    AuthorizerPreset("su -c {command}", "su -c {command}"),
+    AuthorizerPreset("su", "su"),
+    AuthorizerPreset("rish -c {command}", "rish -c {command}"),
+    AuthorizerPreset("su 1000", "su 1000"),
+    AuthorizerPreset("ksu -c {command}", "ksu -c {command}"),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomAuthorizerCard(
     command: String,
@@ -57,38 +86,106 @@ fun CustomAuthorizerCard(
     onTestCommand: suspend (String) -> Result<String>,
     modifier: Modifier = Modifier,
 ) {
-    val scope = rememberCoroutineScope()
-    var isTesting by remember { mutableStateOf(false) }
-    var testResult by remember { mutableStateOf<Result<String>?>(null) }
+    var showSheet by rememberSaveable { mutableStateOf(false) }
 
-    // Maintain local state so typing is immediate and smooth without async DataStore jitter/cursor jumps
-    var localCommand by rememberSaveable { mutableStateOf(command) }
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .clickable { showSheet = true },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.size(42.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Rounded.Terminal,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(14.dp))
+                Column {
+                    Text(
+                        text = stringResource(R.string.setting_custom_authorizer_title),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = command.ifBlank { PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND },
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
 
-    // Sync from external state (e.g. initial load or reset from outside)
-    LaunchedEffect(command) {
-        if (command != localCommand) {
-            localCommand = command
-        }
-    }
-
-    // Debounce updates back to DataStore
-    LaunchedEffect(localCommand) {
-        if (localCommand != command) {
-            delay(300L)
-            onCommandChange(localCommand)
-        }
-    }
-
-    // Flush any pending changes when leaving composition
-    val currentLocalCommand by rememberUpdatedState(localCommand)
-    val currentExternalCommand by rememberUpdatedState(command)
-    DisposableEffect(Unit) {
-        onDispose {
-            if (currentLocalCommand != currentExternalCommand) {
-                onCommandChange(currentLocalCommand)
+            FilledTonalButton(
+                onClick = { showSheet = true },
+                contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp),
+                modifier = Modifier.height(36.dp),
+            ) {
+                Icon(
+                    Icons.Rounded.Tune,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = stringResource(R.string.setting_custom_authorizer_configure),
+                    style = MaterialTheme.typography.labelMedium,
+                )
             }
         }
     }
+
+    if (showSheet) {
+        CustomAuthorizerSheet(
+            initialCommand = command,
+            onSaveCommand = { newCmd ->
+                onCommandChange(newCmd)
+                showSheet = false
+            },
+            onTestCommand = onTestCommand,
+            onDismiss = { showSheet = false },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun CustomAuthorizerSheet(
+    initialCommand: String,
+    onSaveCommand: (String) -> Unit,
+    onTestCommand: suspend (String) -> Result<String>,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    var localCommand by rememberSaveable { mutableStateOf(initialCommand) }
+    var isTesting by remember { mutableStateOf(false) }
+    var testResult by remember { mutableStateOf<Result<String>?>(null) }
 
     val validation = remember(localCommand) { CustomShellExecutor.validateCommand(localCommand) }
     val isError = validation is CustomShellExecutor.ValidationResult.Error
@@ -106,20 +203,84 @@ fun CustomAuthorizerCard(
         else -> null
     }
 
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-        ),
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            // Header
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(14.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    modifier = Modifier.size(46.dp),
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            Icons.Rounded.Terminal,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(14.dp))
+                Column {
+                    Text(
+                        text = stringResource(R.string.setting_custom_authorizer_title),
+                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                    )
+                    Text(
+                        text = stringResource(R.string.setting_custom_authorizer_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            // Quick Presets
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(
+                    text = stringResource(R.string.setting_custom_authorizer_presets),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    PRESETS.forEach { preset ->
+                        val isSelected = localCommand.trim() == preset.command
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = {
+                                localCommand = preset.command
+                                testResult = null
+                            },
+                            label = {
+                                Text(
+                                    text = preset.label,
+                                    fontFamily = FontFamily.Monospace,
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            },
+                        )
+                    }
+                }
+            }
+
+            // Input TextField
             OutlinedTextField(
                 value = localCommand,
                 onValueChange = {
@@ -138,7 +299,6 @@ fun CustomAuthorizerCard(
                         IconButton(
                             onClick = {
                                 localCommand = PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND
-                                onCommandChange(PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND)
                                 testResult = null
                             },
                         ) {
@@ -174,19 +334,15 @@ fun CustomAuthorizerCard(
                 textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
-
+            // Test execution button
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
+                horizontalArrangement = Arrangement.Start,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                FilledTonalButton(
+                OutlinedButton(
                     onClick = {
                         scope.launch {
-                            if (localCommand != command) {
-                                onCommandChange(localCommand)
-                            }
                             isTesting = true
                             testResult = onTestCommand(localCommand)
                             isTesting = false
@@ -212,47 +368,81 @@ fun CustomAuthorizerCard(
                 }
             }
 
+            // Test Result display
             AnimatedVisibility(visible = testResult != null) {
                 testResult?.let { res ->
-                    Spacer(modifier = Modifier.height(10.dp))
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
+                    Card(
                         modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = if (res.isSuccess) {
+                                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+                            } else {
+                                MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f)
+                            },
+                        ),
+                        shape = RoundedCornerShape(12.dp),
                     ) {
-                        if (res.isSuccess) {
-                            Icon(
-                                Icons.Rounded.CheckCircle,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(18.dp),
-                            )
-                            Text(
-                                text = stringResource(
-                                    R.string.setting_custom_authorizer_test_success,
-                                    res.getOrNull().orEmpty(),
-                                ),
-                                style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(start = 8.dp),
-                            )
-                        } else {
-                            Icon(
-                                Icons.Rounded.ErrorOutline,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.size(18.dp),
-                            )
-                            Text(
-                                text = stringResource(
-                                    R.string.setting_custom_authorizer_test_failed,
-                                    res.exceptionOrNull()?.message.orEmpty(),
-                                ),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(start = 8.dp),
-                            )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            if (res.isSuccess) {
+                                Icon(
+                                    Icons.Rounded.CheckCircle,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                                Text(
+                                    text = stringResource(
+                                        R.string.setting_custom_authorizer_test_success,
+                                        res.getOrNull().orEmpty(),
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    modifier = Modifier.padding(start = 10.dp),
+                                )
+                            } else {
+                                Icon(
+                                    Icons.Rounded.ErrorOutline,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(20.dp),
+                                )
+                                Text(
+                                    text = stringResource(
+                                        R.string.setting_custom_authorizer_test_failed,
+                                        res.exceptionOrNull()?.message.orEmpty(),
+                                    ),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onErrorContainer,
+                                    modifier = Modifier.padding(start = 10.dp),
+                                )
+                            }
                         }
                     }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Action Bar (Cancel / Save)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.cancel))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { onSaveCommand(localCommand) },
+                    enabled = !isError && localCommand.isNotBlank(),
+                ) {
+                    Text(stringResource(R.string.setting_custom_authorizer_save))
                 }
             }
         }

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/SettingComponents.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/components/SettingComponents.kt
@@ -57,6 +57,11 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material.icons.rounded.Android
+import androidx.compose.material.icons.rounded.Shield
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
@@ -72,6 +77,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.ui.draw.alpha
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -276,6 +282,7 @@ internal fun InstallModeSelector(
             add(InstallMode.SHIZUKU)
             if (dhizukuSupported) add(InstallMode.DHIZUKU)
             if (rootSupported) add(InstallMode.ROOT)
+            add(InstallMode.CUSTOM)
         }
     }
     Column(
@@ -302,18 +309,21 @@ internal fun InstallModeSelector(
         val dhizukuDimmed = currentMode != InstallMode.DHIZUKU &&
             (dhizukuState == DhizukuState.NOT_INSTALLED || dhizukuState == DhizukuState.UNSUPPORTED || dhizukuState == DhizukuState.PROFILE_OWNER_UNSUPPORTED)
 
-        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-            options.forEachIndexed { index, mode ->
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            options.forEach { mode ->
                 val dim = (mode == InstallMode.ROOT && rootDimmed) || (mode == InstallMode.DHIZUKU && dhizukuDimmed)
-                SegmentedButton(
-                    selected = mode == currentMode,
+                val selected = mode == currentMode
+                FilterChip(
+                    selected = selected,
                     onClick = {
                         if (mode != currentMode || (mode == InstallMode.DHIZUKU && dhizukuState == DhizukuState.NOT_AUTHORIZED)) {
                             onModeChange(mode)
                         }
                     },
-                    shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                    enabled = true,
                     label = {
                         Text(
                             text = when (mode) {
@@ -321,13 +331,30 @@ internal fun InstallModeSelector(
                                 InstallMode.SHIZUKU -> stringResource(R.string.setting_install_mode_shizuku)
                                 InstallMode.DHIZUKU -> stringResource(R.string.setting_install_mode_dhizuku)
                                 InstallMode.ROOT -> stringResource(R.string.setting_install_mode_root)
+                                InstallMode.CUSTOM -> stringResource(R.string.setting_install_mode_custom)
                             },
-                            color = if (dim)
-                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-                            else
-                                androidx.compose.ui.graphics.Color.Unspecified,
                         )
                     },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = when (mode) {
+                                InstallMode.DEFAULT -> Icons.Rounded.Android
+                                InstallMode.SHIZUKU -> Icons.Rounded.Key
+                                InstallMode.DHIZUKU -> Icons.Rounded.AdminPanelSettings
+                                InstallMode.ROOT -> Icons.Rounded.Shield
+                                InstallMode.CUSTOM -> Icons.Rounded.Terminal
+                            },
+                            contentDescription = null,
+                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                        )
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                    modifier = if (dim) Modifier.alpha(0.38f) else Modifier,
                 )
             }
         }
@@ -355,6 +382,7 @@ internal fun InstallModeSelector(
                 RootState.READY -> "Ready"
                 else -> "Not Rooted"
             }
+            InstallMode.CUSTOM -> stringResource(R.string.setting_install_mode_custom_sub)
         }
         val canRequestPermission = currentMode == InstallMode.DHIZUKU && dhizukuState == DhizukuState.NOT_AUTHORIZED
         Text(

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/profile/edit/ProfileEditScreen.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/profile/edit/ProfileEditScreen.kt
@@ -17,16 +17,24 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Android
 import androidx.compose.material.icons.rounded.Badge
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.DriveFileRenameOutline
+import androidx.compose.material.icons.rounded.Key
 import androidx.compose.material.icons.rounded.Layers
 import androidx.compose.material.icons.automirrored.rounded.List
 import androidx.compose.material.icons.rounded.SettingsApplications
+import androidx.compose.material.icons.rounded.Shield
+import androidx.compose.material.icons.rounded.Terminal
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -283,25 +291,49 @@ private fun ProfileEditUi(
                     val rootSelectable = rootState == app.pwhs.universalinstaller.presentation.install.controller.RootState.READY ||
                         rootState == app.pwhs.universalinstaller.presentation.install.controller.RootState.DENIED ||
                         rootState == app.pwhs.universalinstaller.presentation.install.controller.RootState.UNKNOWN
-                    val options = if (rootSupported) listOf("Default", "Shizuku", "Root")
-                        else listOf("Default", "Shizuku")
+                    val options = if (rootSupported) listOf("Default", "Shizuku", "Root", "Custom")
+                        else listOf("Default", "Shizuku", "Custom")
                     Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                            options.forEachIndexed { index, b ->
-                                SegmentedButton(
-                                    selected = backend == b,
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            options.forEach { b ->
+                                val enabled = b != "Root" || rootSelectable
+                                val selected = backend == b
+                                FilterChip(
+                                    selected = selected,
                                     onClick = { if (backend != b) onBackendChange(b) },
-                                    shape = SegmentedButtonDefaults.itemShape(index = index, count = options.size),
-                                    enabled = b != "Root" || rootSelectable,
+                                    enabled = enabled,
                                     label = {
                                         Text(
                                             text = when (b) {
                                                 "Default" -> stringResource(R.string.setting_install_mode_default)
                                                 "Shizuku" -> stringResource(R.string.setting_install_mode_shizuku)
-                                                else -> stringResource(R.string.setting_install_mode_root)
+                                                "Root" -> stringResource(R.string.setting_install_mode_root)
+                                                else -> stringResource(R.string.setting_install_mode_custom)
                                             },
                                         )
                                     },
+                                    leadingIcon = {
+                                        Icon(
+                                            imageVector = when (b) {
+                                                "Default" -> Icons.Rounded.Android
+                                                "Shizuku" -> Icons.Rounded.Key
+                                                "Root" -> Icons.Rounded.Shield
+                                                else -> Icons.Rounded.Terminal
+                                            },
+                                            contentDescription = null,
+                                            modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                        )
+                                    },
+                                    shape = RoundedCornerShape(12.dp),
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                        selectedLeadingIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    ),
                                 )
                             }
                         }

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/sections/InstallSection.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/sections/InstallSection.kt
@@ -26,6 +26,7 @@ import app.pwhs.universalinstaller.presentation.setting.InstallMode
 import app.pwhs.universalinstaller.presentation.install.controller.RootState
 import app.pwhs.universalinstaller.presentation.setting.SettingUiState
 import app.pwhs.universalinstaller.presentation.setting.ShizukuState
+import app.pwhs.universalinstaller.presentation.setting.components.CustomAuthorizerCard
 import app.pwhs.universalinstaller.presentation.setting.components.InstallModeSelector
 import app.pwhs.universalinstaller.presentation.setting.components.OptionGroupHeader
 import app.pwhs.universalinstaller.presentation.setting.components.SearchableItem
@@ -44,16 +45,19 @@ internal fun LazyListScope.InstallSection(
     onRootRetry: () -> Unit,
     onDeleteApkChanged: (Boolean) -> Unit,
     onAutoOpenAfterInstallChanged: (Boolean) -> Unit,
-    onDefaultInstallerChanged: (Boolean) -> Unit
+    onDefaultInstallerChanged: (Boolean) -> Unit,
+    onCustomAuthorizerCommandChange: (String) -> Unit = {},
+    onTestCustomAuthorizerCommand: suspend (String) -> Result<String> = { Result.success("") },
 ) {
     if (matchesQuery(q, installLabels)) item {
         SettingsSection(title = stringResource(R.string.setting_section_installation), icon = Icons.Rounded.SettingsApplications) {
             // Group headers only while unfiltered: a header whose items were all
             // searched away is a label over nothing. Same rule the divider below uses.
             if (q.isBlank()) OptionGroupHeader(stringResource(R.string.setting_group_installing))
-            SearchableItem(q, stringResource(R.string.setting_install_mode_title), "shizuku dhizuku root default") {
+            SearchableItem(q, stringResource(R.string.setting_install_mode_title), "shizuku dhizuku root default custom") {
+                val currentMode = InstallMode.from(uiState.useShizuku, uiState.useRoot, useDhizuku, uiState.useCustomAuthorizer)
                 InstallModeSelector(
-                    currentMode = InstallMode.from(uiState.useShizuku, uiState.useRoot, useDhizuku),
+                    currentMode = currentMode,
                     shizukuState = uiState.shizukuState,
                     rootSupported = uiState.rootSupported,
                     rootState = uiState.rootState,
@@ -61,6 +65,13 @@ internal fun LazyListScope.InstallSection(
                     dhizukuState = dhizukuState,
                     onModeChange = onInstallModeChanged,
                 )
+                if (currentMode == InstallMode.CUSTOM) {
+                    CustomAuthorizerCard(
+                        command = uiState.customAuthorizerCommand,
+                        onCommandChange = onCustomAuthorizerCommandChange,
+                        onTestCommand = onTestCustomAuthorizerCommand,
+                    )
+                }
                 if (uiState.rootSupported && uiState.useRoot && uiState.rootState == RootState.DENIED) {
                     ListItem(
                         headlineContent = { Text(stringResource(R.string.setting_retry_root)) },

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/util/SettingPrivilegeDelegate.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/util/SettingPrivilegeDelegate.kt
@@ -49,6 +49,14 @@ class SettingPrivilegeDelegate(
         .map { it[PreferencesKeys.USE_DHIZUKU] ?: false }
         .stateIn(scope, SharingStarted.Eagerly, false)
 
+    val useCustomAuthorizer: StateFlow<Boolean> = dataStore.data
+        .map { it[PreferencesKeys.USE_CUSTOM_AUTHORIZER] ?: false }
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
+    val customAuthorizerCommand: StateFlow<String> = dataStore.data
+        .map { it[PreferencesKeys.CUSTOM_AUTHORIZER_COMMAND] ?: PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND }
+        .stateIn(scope, SharingStarted.Eagerly, PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND)
+
     private val _rootState = MutableStateFlow(
         if (backendFactory.rootSupportCompiledIn) RootState.UNKNOWN else RootState.UNAVAILABLE,
     )
@@ -79,6 +87,7 @@ class SettingPrivilegeDelegate(
                     dataStore.edit { prefs ->
                         prefs[PreferencesKeys.USE_ROOT] = false
                         prefs[PreferencesKeys.USE_DHIZUKU] = false
+                        prefs[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
                         prefs[PreferencesKeys.USE_SHIZUKU] = true
                     }
                 }
@@ -124,6 +133,7 @@ class SettingPrivilegeDelegate(
                     p[PreferencesKeys.USE_SHIZUKU] = false
                     p[PreferencesKeys.USE_ROOT] = false
                     p[PreferencesKeys.USE_DHIZUKU] = false
+                    p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
                 }
             }
             InstallMode.SHIZUKU -> {
@@ -131,6 +141,7 @@ class SettingPrivilegeDelegate(
                     dataStore.edit { p ->
                         p[PreferencesKeys.USE_ROOT] = false
                         p[PreferencesKeys.USE_DHIZUKU] = false
+                        p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
                     }
                 }
                 setUseShizuku(true)
@@ -140,6 +151,7 @@ class SettingPrivilegeDelegate(
                     dataStore.edit { p ->
                         p[PreferencesKeys.USE_SHIZUKU] = false
                         p[PreferencesKeys.USE_ROOT] = false
+                        p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
                     }
                 }
                 setUseDhizuku(true)
@@ -151,8 +163,17 @@ class SettingPrivilegeDelegate(
                     dataStore.edit { p ->
                         p[PreferencesKeys.USE_SHIZUKU] = false
                         p[PreferencesKeys.USE_DHIZUKU] = false
+                        p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
                         p[PreferencesKeys.USE_ROOT] = true
                     }
+                }
+            }
+            InstallMode.CUSTOM -> scope.launch {
+                dataStore.edit { p ->
+                    p[PreferencesKeys.USE_SHIZUKU] = false
+                    p[PreferencesKeys.USE_ROOT] = false
+                    p[PreferencesKeys.USE_DHIZUKU] = false
+                    p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = true
                 }
             }
         }
@@ -236,7 +257,14 @@ class SettingPrivilegeDelegate(
         dataStore.edit { p ->
             p[PreferencesKeys.USE_SHIZUKU] = false
             p[PreferencesKeys.USE_ROOT] = false
+            p[PreferencesKeys.USE_CUSTOM_AUTHORIZER] = false
             p[PreferencesKeys.USE_DHIZUKU] = true
+        }
+    }
+
+    fun setCustomAuthorizerCommand(command: String) = scope.launch {
+        dataStore.edit { p ->
+            p[PreferencesKeys.CUSTOM_AUTHORIZER_COMMAND] = command
         }
     }
 

--- a/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/util/SettingUiStateBuilder.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/presentation/setting/util/SettingUiStateBuilder.kt
@@ -50,6 +50,8 @@ object SettingUiStateBuilder {
         val autoApproveCount = extractorAndProfiles.getOrNull(4)?.toIntOrNull() ?: 0
         val selectedLang = flows[13] as String
         val isDefault = flows[14] as Boolean
+        val useCustomAuthorizer = flows.getOrNull(15) as? Boolean ?: false
+        val customAuthorizerCommand = flows.getOrNull(16) as? String ?: ""
 
         val versionName = try {
             application.packageManager
@@ -93,6 +95,8 @@ object SettingUiStateBuilder {
             appProfileMapping = ProfileManager.parseMapping(mappingJson),
             selectedLanguage = selectedLang,
             isDefaultInstaller = isDefault,
+            useCustomAuthorizer = useCustomAuthorizer,
+            customAuthorizerCommand = customAuthorizerCommand,
         )
     }
 }

--- a/app/src/main/java/app/pwhs/universalinstaller/util/CustomShellExecutor.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/util/CustomShellExecutor.kt
@@ -23,6 +23,65 @@ object CustomShellExecutor {
 
     const val COMMAND_PLACEHOLDER = "{command}"
 
+    sealed class ValidationResult {
+        data object Valid : ValidationResult()
+        data class Error(val reason: ValidationErrorReason, val detail: String = "") : ValidationResult()
+    }
+
+    enum class ValidationErrorReason {
+        BLANK,
+        DANGEROUS_COMMAND,
+        NOT_AUTHORIZER_BINARY,
+        MISSING_PLACEHOLDER,
+    }
+
+    private val DANGEROUS_BINARIES = setOf(
+        "rm", "rmdir", "dd", "mkfs", "format", "wipe", "reboot", "shutdown",
+        "halt", "poweroff", "fastboot", "recovery"
+    )
+
+    private val NON_AUTHORIZER_UTILITIES = setOf(
+        "ls", "cat", "echo", "mkdir", "touch", "cp", "mv", "grep", "sed", "awk",
+        "find", "sleep", "kill", "killall", "ps", "top", "df", "du", "tail", "head",
+        "tar", "zip", "unzip", "gzip", "curl", "wget"
+    )
+
+    fun validateCommand(command: String): ValidationResult {
+        val trimmed = command.trim()
+        if (trimmed.isBlank()) {
+            return ValidationResult.Error(ValidationErrorReason.BLANK)
+        }
+
+        val tokens = parseCommand(trimmed)
+        if (tokens.isEmpty()) {
+            return ValidationResult.Error(ValidationErrorReason.BLANK)
+        }
+
+        val allWords = tokens.flatMap { it.split(Regex("[\\s'\"`|;&]+")) }
+            .map { it.lowercase().substringAfterLast('/') }
+            .filter { it.isNotBlank() }
+
+        // 1. Destructive commands check
+        val dangerousWord = allWords.firstOrNull { it in DANGEROUS_BINARIES }
+        if (dangerousWord != null) {
+            return ValidationResult.Error(ValidationErrorReason.DANGEROUS_COMMAND, dangerousWord)
+        }
+
+        // 2. Common non-authorizer shell utilities check
+        val baseBinary = tokens.first().lowercase().substringAfterLast('/')
+        if (baseBinary in NON_AUTHORIZER_UTILITIES) {
+            return ValidationResult.Error(ValidationErrorReason.NOT_AUTHORIZER_BINARY, baseBinary)
+        }
+
+        // 3. Flags like -c, --command, /c require {command} placeholder
+        val flag = tokens.firstOrNull { it in listOf("-c", "/c", "--command", "-command") }
+        if (flag != null && !trimmed.contains(COMMAND_PLACEHOLDER)) {
+            return ValidationResult.Error(ValidationErrorReason.MISSING_PLACEHOLDER, flag)
+        }
+
+        return ValidationResult.Valid
+    }
+
     data class Result(
         val code: Int,
         val out: List<String>,
@@ -49,6 +108,10 @@ object CustomShellExecutor {
 
     suspend fun testCommand(template: String): kotlin.Result<String> = withContext(Dispatchers.IO) {
         runCatching {
+            val validation = validateCommand(template)
+            if (validation is ValidationResult.Error) {
+                throw IllegalArgumentException("Invalid command: ${validation.reason} (${validation.detail})")
+            }
             val result = execWithTemplate(template, "id", timeoutSeconds = 8L)
             if (result.isSuccess) {
                 val line = result.out.firstOrNull { it.contains("uid=", ignoreCase = true) }
@@ -68,6 +131,12 @@ object CustomShellExecutor {
         timeoutSeconds: Long = 60L,
     ): Result = withContext(Dispatchers.IO) {
         val cleanTemplate = template.trim().ifBlank { PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND }
+        val validation = validateCommand(cleanTemplate)
+        if (validation is ValidationResult.Error) {
+            val msg = "Unsafe or invalid authorizer command: ${validation.reason} (${validation.detail})"
+            Timber.e(msg)
+            return@withContext Result(-1, emptyList(), listOf(msg))
+        }
         val parts = parseCommand(cleanTemplate)
         if (parts.isEmpty()) {
             return@withContext Result(-1, emptyList(), listOf("Empty custom authorizer command"))

--- a/app/src/main/java/app/pwhs/universalinstaller/util/CustomShellExecutor.kt
+++ b/app/src/main/java/app/pwhs/universalinstaller/util/CustomShellExecutor.kt
@@ -1,0 +1,169 @@
+package app.pwhs.universalinstaller.util
+
+import android.content.Context
+import app.pwhs.core.data.local.dataStore
+import app.pwhs.universalinstaller.presentation.setting.PreferencesKeys
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.PrintWriter
+import java.util.concurrent.TimeUnit
+
+/**
+ * Executes shell commands through a user-configured authorizer template.
+ *
+ * Supports two execution modes inspired by InstallerX-Revived:
+ * 1. Placeholder mode: When the template contains `{command}`, the placeholder is replaced
+ *    with the command arguments (e.g. `su -c {command}` or `sh /path/to/rish -c {command}`).
+ * 2. Stdin terminal mode: When no placeholder is present, the process is started with the
+ *    template tokens (e.g. `su 1000` or `su`), and the command is piped to its stdin.
+ */
+object CustomShellExecutor {
+
+    const val COMMAND_PLACEHOLDER = "{command}"
+
+    data class Result(
+        val code: Int,
+        val out: List<String>,
+        val err: List<String>,
+    ) {
+        val isSuccess: Boolean get() = code == 0
+        val text: String get() = (out + err).joinToString("\n").trim()
+    }
+
+    suspend fun getCommandTemplate(context: Context): String {
+        val prefs = runCatching { context.dataStore.data.first() }.getOrNull()
+        return prefs?.get(PreferencesKeys.CUSTOM_AUTHORIZER_COMMAND)?.trim()?.ifBlank { null }
+            ?: PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND
+    }
+
+    suspend fun exec(
+        context: Context,
+        command: String,
+        timeoutSeconds: Long = 60L,
+    ): Result {
+        val template = getCommandTemplate(context)
+        return execWithTemplate(template, command, timeoutSeconds)
+    }
+
+    suspend fun testCommand(template: String): kotlin.Result<String> = withContext(Dispatchers.IO) {
+        runCatching {
+            val result = execWithTemplate(template, "id", timeoutSeconds = 8L)
+            if (result.isSuccess) {
+                val line = result.out.firstOrNull { it.contains("uid=", ignoreCase = true) }
+                    ?: result.out.firstOrNull()?.trim()
+                    ?: "OK (exit 0)"
+                line.trim()
+            } else {
+                val err = result.err.joinToString("\n").ifBlank { result.out.joinToString("\n") }
+                throw RuntimeException("Exit code ${result.code}: ${err.ifBlank { "Command failed" }}")
+            }
+        }
+    }
+
+    suspend fun execWithTemplate(
+        template: String,
+        command: String,
+        timeoutSeconds: Long = 60L,
+    ): Result = withContext(Dispatchers.IO) {
+        val cleanTemplate = template.trim().ifBlank { PreferencesKeys.DEFAULT_CUSTOM_AUTHORIZER_COMMAND }
+        val parts = parseCommand(cleanTemplate)
+        if (parts.isEmpty()) {
+            return@withContext Result(-1, emptyList(), listOf("Empty custom authorizer command"))
+        }
+
+        try {
+            val hasPlaceholder = parts.any { it.contains(COMMAND_PLACEHOLDER) }
+            val process = if (hasPlaceholder) {
+                val cmdList = parts.map { part ->
+                    if (part.contains(COMMAND_PLACEHOLDER)) {
+                        part.replace(COMMAND_PLACEHOLDER, command)
+                    } else {
+                        part
+                    }
+                }
+                ProcessBuilder(cmdList).start()
+            } else {
+                val process = ProcessBuilder(parts).start()
+                PrintWriter(process.outputStream, true).use { writer ->
+                    writer.println(command)
+                    writer.println("exit $?")
+                }
+                process
+            }
+
+            val outLines = mutableListOf<String>()
+            val errLines = mutableListOf<String>()
+
+            val outReader = Thread {
+                process.inputStream.bufferedReader().useLines { lines ->
+                    lines.forEach { outLines.add(it) }
+                }
+            }
+            val errReader = Thread {
+                process.errorStream.bufferedReader().useLines { lines ->
+                    lines.forEach { errLines.add(it) }
+                }
+            }
+            outReader.start()
+            errReader.start()
+
+            val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return@withContext Result(-1, outLines, listOf("Command timed out after ${timeoutSeconds}s"))
+            }
+
+            outReader.join(1000)
+            errReader.join(1000)
+
+            Result(process.exitValue(), outLines, errLines)
+        } catch (e: Exception) {
+            Timber.e(e, "CustomShellExecutor failed to execute command: $command")
+            Result(-1, emptyList(), listOf(e.message ?: "Execution failed"))
+        }
+    }
+
+    /**
+     * Splits command string into tokens respecting single and double quotes.
+     */
+    fun parseCommand(command: String): List<String> {
+        val result = mutableListOf<String>()
+        val current = StringBuilder()
+        var inSingleQuote = false
+        var inDoubleQuote = false
+        var escaped = false
+
+        for (char in command) {
+            when {
+                escaped -> {
+                    current.append(char)
+                    escaped = false
+                }
+                char == '\\' -> {
+                    escaped = true
+                }
+                char == '\'' && !inDoubleQuote -> {
+                    inSingleQuote = !inSingleQuote
+                }
+                char == '"' && !inSingleQuote -> {
+                    inDoubleQuote = !inDoubleQuote
+                }
+                char.isWhitespace() && !inSingleQuote && !inDoubleQuote -> {
+                    if (current.isNotEmpty()) {
+                        result.add(current.toString())
+                        current.setLength(0)
+                    }
+                }
+                else -> {
+                    current.append(char)
+                }
+            }
+        }
+        if (current.isNotEmpty()) {
+            result.add(current.toString())
+        }
+        return result
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">اضغط لمنح إذن Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">تم تعيين Dhizuku كمالك ملف شخصي. يتطلب التثبيت الصامت مالك الجهاز.</string>
     <string name="installer_engine_dhizuku_desc">تثبيت صامت عبر مالك الجهاز</string>
+    <string name="setting_install_mode_custom">مخصص</string>
+    <string name="setting_install_mode_custom_sub">التثبيت عبر أوامر shell أو تفويض مخصص</string>
+    <string name="setting_custom_authorizer_title">المفوض المخصص</string>
+    <string name="setting_custom_authorizer_subtitle">تكوين أمر shell أو برنامج ثنائي لتفويض عمليات التثبيت</string>
+    <string name="setting_custom_authorizer_configure">تهيئة</string>
+    <string name="setting_custom_authorizer_presets">نماذج جاهزة</string>
+    <string name="setting_custom_authorizer_save">حفظ وتطبيق</string>
+    <string name="setting_custom_authorizer_cmd_label">أمر التفويض</string>
+    <string name="setting_custom_authorizer_cmd_hint">مثال: su -c {command} أو su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">يدعم العنصر النائب {command} أو وضع موجه أوامر stdin (مثل su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">اختبار</string>
+    <string name="setting_custom_authorizer_test_success">متصل: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">فشل: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">لا يمكن ترك الأمر فارغاً</string>
+    <string name="setting_custom_authorizer_err_dangerous">تم اكتشاف أمر خطير (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' ليس أداة تفويض (استخدم su, ksu, rish, sh, إلخ)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">العنصر النائب {command} مفقود لعلامة %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">إعادة الضبط إلى الافتراضي</string>
+    <string name="installer_mode_custom">مخصص</string>
+    <string name="installer_engine_custom_desc">التثبيت عبر أمر تفويض مخصص</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Tippen, um Dhizuku-Berechtigung zu erteilen</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku ist als Profilinhaber festgelegt. Die stille Installation erfordert den Geräteinhaber.</string>
     <string name="installer_engine_dhizuku_desc">Lautlos über den Geräteinhaber installieren</string>
+    <string name="setting_install_mode_custom">Benutzerdefiniert</string>
+    <string name="setting_install_mode_custom_sub">Über benutzerdefinierte Shell oder Autorisierungsbefehl installieren</string>
+    <string name="setting_custom_authorizer_title">Benutzerdefinierter Autorisierer</string>
+    <string name="setting_custom_authorizer_subtitle">Benutzerdefinierte Shell oder Binärdatei zum Autorisieren von Installationen konfigurieren</string>
+    <string name="setting_custom_authorizer_configure">Konfigurieren</string>
+    <string name="setting_custom_authorizer_presets">Schnellvorlagen</string>
+    <string name="setting_custom_authorizer_save">Speichern &amp; Anwenden</string>
+    <string name="setting_custom_authorizer_cmd_label">Autorisierungsbefehl</string>
+    <string name="setting_custom_authorizer_cmd_hint">z.B. su -c {command} oder su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Unterstützt {command}-Platzhalter oder stdin-Terminalmodus (z.B. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Testen</string>
+    <string name="setting_custom_authorizer_test_success">Verbunden: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Fehlgeschlagen: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Befehl darf nicht leer sein</string>
+    <string name="setting_custom_authorizer_err_dangerous">Gefährlicher Befehl erkannt (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' ist kein Autorisierer (verwenden Sie su, ksu, rish, sh usw.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Fehlender {command}-Platzhalter für Flag %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Auf Standard zurücksetzen</string>
+    <string name="installer_mode_custom">Benutzerdefiniert</string>
+    <string name="installer_engine_custom_desc">Über benutzerdefinierten Autorisierungsbefehl installieren</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Πατήστε για παραχώρηση άδειας Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Το Dhizuku έχει οριστεί ως Κάτοχος προφίλ. Η σιωπηλή εγκατάσταση απαιτεί Κάτοχο συσκευής.</string>
     <string name="installer_engine_dhizuku_desc">Σιωπηλή εγκατάσταση μέσω Κατόχου συσκευής</string>
+    <string name="setting_install_mode_custom">Προσαρμοσμένο</string>
+    <string name="setting_install_mode_custom_sub">Εγκατάσταση μέσω προσαρμοσμένου κελύφους ή εντολής εξουσιοδότησης</string>
+    <string name="setting_custom_authorizer_title">Προσαρμοσμένος Εξουσιοδοτητής</string>
+    <string name="setting_custom_authorizer_subtitle">Διαμόρφωση προσαρμοσμένου κελύφους ή εκτελέσιμου για εξουσιοδότηση εγκαταστάσεων</string>
+    <string name="setting_custom_authorizer_configure">Διαμόρφωση</string>
+    <string name="setting_custom_authorizer_presets">Γρήγορες προεπιλογές</string>
+    <string name="setting_custom_authorizer_save">Αποθήκευση &amp; Εφαρμογή</string>
+    <string name="setting_custom_authorizer_cmd_label">Εντολή εξουσιοδότησης</string>
+    <string name="setting_custom_authorizer_cmd_hint">π.χ. su -c {command} ή su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Υποστηρίζει το σύμβολο κράτησης θέσης {command} ή λειτουργία τερματικού stdin (π.χ. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Δοκιμή</string>
+    <string name="setting_custom_authorizer_test_success">Συνδέθηκε: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Απέτυχε: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Η εντολή δεν μπορεί να είναι κενή</string>
+    <string name="setting_custom_authorizer_err_dangerous">Εντοπίστηκε επικίνδυνη εντολή (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">Το \'%1$s\' δεν είναι εργαλείο εξουσιοδότησης (χρησιμοποιήστε su, ksu, rish, sh, κλπ.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Λείπει το σύμβολο κράτησης θέσης {command} για τη σημαία %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Επαναφορά προεπιλογής</string>
+    <string name="installer_mode_custom">Προσαρμοσμένο</string>
+    <string name="installer_engine_custom_desc">Εγκατάσταση μέσω προσαρμοσμένης εντολής εξουσιοδότησης</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Toca para conceder el permiso de Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku está configurado como Propietario de perfil. La instalación silenciosa requiere Propietario del dispositivo.</string>
     <string name="installer_engine_dhizuku_desc">Instalar silenciosamente mediante el Propietario del dispositivo</string>
+    <string name="setting_install_mode_custom">Personalizado</string>
+    <string name="setting_install_mode_custom_sub">Instalar mediante shell personalizado o comando de autorización</string>
+    <string name="setting_custom_authorizer_title">Autorizador personalizado</string>
+    <string name="setting_custom_authorizer_subtitle">Configurar shell o binario personalizado para autorizar instalaciones</string>
+    <string name="setting_custom_authorizer_configure">Configurar</string>
+    <string name="setting_custom_authorizer_presets">Plantillas rápidas</string>
+    <string name="setting_custom_authorizer_save">Guardar y aplicar</string>
+    <string name="setting_custom_authorizer_cmd_label">Comando autorizador</string>
+    <string name="setting_custom_authorizer_cmd_hint">ej. su -c {command} o su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Admite el marcador de posición {command} o modo terminal stdin (ej. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Probar</string>
+    <string name="setting_custom_authorizer_test_success">Conectado: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Falló: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">El comando no puede estar vacío</string>
+    <string name="setting_custom_authorizer_err_dangerous">Comando peligroso detectado (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' no es un autorizador (use su, ksu, rish, sh, etc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Falta el marcador de posición {command} para el parámetro %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Restablecer a predeterminado</string>
+    <string name="installer_mode_custom">Personalizado</string>
+    <string name="installer_engine_custom_desc">Instalar mediante comando de autorización personalizado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Appuyez pour accorder la permission Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku est défini comme propriétaire de profil. L\'installation silencieuse nécessite le propriétaire de l\'appareil.</string>
     <string name="installer_engine_dhizuku_desc">Installation silencieuse via le propriétaire de l\'appareil</string>
+    <string name="setting_install_mode_custom">Personnalisé</string>
+    <string name="setting_install_mode_custom_sub">Installer via un shell ou une commande d\'autorisation personnalisée</string>
+    <string name="setting_custom_authorizer_title">Autorisateur personnalisé</string>
+    <string name="setting_custom_authorizer_subtitle">Configurer un shell ou un binaire personnalisé pour autoriser les installations</string>
+    <string name="setting_custom_authorizer_configure">Configurer</string>
+    <string name="setting_custom_authorizer_presets">Modèles rapides</string>
+    <string name="setting_custom_authorizer_save">Enregistrer et appliquer</string>
+    <string name="setting_custom_authorizer_cmd_label">Commande d\'autorisation</string>
+    <string name="setting_custom_authorizer_cmd_hint">ex. su -c {command} ou su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Prend en charge l\'espace réservé {command} ou le mode terminal stdin (ex. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Tester</string>
+    <string name="setting_custom_authorizer_test_success">Connecté : %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Échec : %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">La commande ne peut pas être vide</string>
+    <string name="setting_custom_authorizer_err_dangerous">Commande dangereuse détectée (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' n\'est pas un autorisateur (utilisez su, ksu, rish, sh, etc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Espace réservé {command} manquant pour l\'option %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Rétablir par défaut</string>
+    <string name="installer_mode_custom">Personnalisé</string>
+    <string name="installer_engine_custom_desc">Installer via une commande d\'autorisation personnalisée</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Dhizuku अनुमति देने के लिए टैप करें</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku को प्रोफ़ाइल स्वामी के रूप में सेट किया गया है। साइलेंट इंस्टॉल के लिए डिवाइस स्वामी आवश्यक है।</string>
     <string name="installer_engine_dhizuku_desc">डिवाइस स्वामी द्वारा साइलेंट इंस्टॉल</string>
+    <string name="setting_install_mode_custom">कस्टम</string>
+    <string name="setting_install_mode_custom_sub">कस्टम शेल या ऑथराइज़र कमांड के माध्यम से इंस्टॉल करें</string>
+    <string name="setting_custom_authorizer_title">कस्टम ऑथराइज़र</string>
+    <string name="setting_custom_authorizer_subtitle">इंस्टॉलेशन अधिकृत करने के लिए कस्टम शेल या बाइनरी कॉन्फ़िगर करें</string>
+    <string name="setting_custom_authorizer_configure">कॉन्फ़िगर करें</string>
+    <string name="setting_custom_authorizer_presets">त्वरित प्रीसेट</string>
+    <string name="setting_custom_authorizer_save">सहेजें और लागू करें</string>
+    <string name="setting_custom_authorizer_cmd_label">ऑथराइज़र कमांड</string>
+    <string name="setting_custom_authorizer_cmd_hint">उदा. su -c {command} या su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">{command} प्लेसहोल्डर या stdin टर्मिनल मोड का समर्थन करता है (उदा. su, su 1000, rish -c {command})।</string>
+    <string name="setting_custom_authorizer_test">परीक्षण करें</string>
+    <string name="setting_custom_authorizer_test_success">कनेक्टेड: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">विफल: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">कमांड खाली नहीं हो सकता</string>
+    <string name="setting_custom_authorizer_err_dangerous">खतरनाक कमांड का पता चला (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' एक ऑथराइज़र नहीं है (su, ksu, rish, sh, आदि का उपयोग करें)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">%1$s फ्लैग के लिए {command} प्लेसहोल्डर गायब है</string>
+    <string name="setting_custom_authorizer_reset_default">डिफ़ॉल्ट पर रीसेट करें</string>
+    <string name="installer_mode_custom">कस्टम</string>
+    <string name="installer_engine_custom_desc">कस्टम ऑथराइज़र कमांड के माध्यम से इंस्टॉल करें</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Ketuk untuk memberikan izin Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku disetel sebagai Pemilik Profil. Pemasangan diam-diam memerlukan Pemilik Perangkat.</string>
     <string name="installer_engine_dhizuku_desc">Instal diam-diam melalui Pemilik Perangkat</string>
+    <string name="setting_install_mode_custom">Kustom</string>
+    <string name="setting_install_mode_custom_sub">Instal melalui shell kustom atau perintah pengesah</string>
+    <string name="setting_custom_authorizer_title">Pengesah Kustom</string>
+    <string name="setting_custom_authorizer_subtitle">Konfigurasikan shell atau biner kustom untuk mengotorisasi pemasangan</string>
+    <string name="setting_custom_authorizer_configure">Konfigurasi</string>
+    <string name="setting_custom_authorizer_presets">Preset Cepat</string>
+    <string name="setting_custom_authorizer_save">Simpan &amp; Terapkan</string>
+    <string name="setting_custom_authorizer_cmd_label">Perintah pengesah</string>
+    <string name="setting_custom_authorizer_cmd_hint">cth. su -c {command} atau su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Mendukung placeholder {command} atau mode terminal stdin (cth. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Uji</string>
+    <string name="setting_custom_authorizer_test_success">Terhubung: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Gagal: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Perintah tidak boleh kosong</string>
+    <string name="setting_custom_authorizer_err_dangerous">Perintah berbahaya terdeteksi (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' bukan pengesah (gunakan su, ksu, rish, sh, dll.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Placeholder {command} tidak ditemukan untuk flag %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Atur ulang ke default</string>
+    <string name="installer_mode_custom">Kustom</string>
+    <string name="installer_engine_custom_desc">Instal melalui perintah pengesah kustom</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Tocca per concedere l\'autorizzazione a Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku è impostato come proprietario del profilo. L\'installazione silenziosa richiede il proprietario del dispositivo.</string>
     <string name="installer_engine_dhizuku_desc">Installazione silenziosa tramite il proprietario del dispositivo</string>
+    <string name="setting_install_mode_custom">Personalizzato</string>
+    <string name="setting_install_mode_custom_sub">Installa tramite shell personalizzata o comando autorizzatore</string>
+    <string name="setting_custom_authorizer_title">Autorizzatore personalizzato</string>
+    <string name="setting_custom_authorizer_subtitle">Configura una shell o un binario personalizzato per autorizzare le installazioni</string>
+    <string name="setting_custom_authorizer_configure">Configura</string>
+    <string name="setting_custom_authorizer_presets">Modelli rapidi</string>
+    <string name="setting_custom_authorizer_save">Salva e applica</string>
+    <string name="setting_custom_authorizer_cmd_label">Comando autorizzatore</string>
+    <string name="setting_custom_authorizer_cmd_hint">es. su -c {command} o su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Supporta il segnaposto {command} o la modalità terminale stdin (es. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Verifica</string>
+    <string name="setting_custom_authorizer_test_success">Connesso: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Non riuscito: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Il comando non può essere vuoto</string>
+    <string name="setting_custom_authorizer_err_dangerous">Rilevato comando pericoloso (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' non è un autorizzatore (usa su, ksu, rish, sh, ecc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Segnaposto {command} mancante per il flag %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Ripristina predefinito</string>
+    <string name="installer_mode_custom">Personalizzato</string>
+    <string name="installer_engine_custom_desc">Installa tramite comando autorizzatore personalizzato</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">タップして Dhizuku に権限を付与</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku はプロファイルオーナーとして設定されています。サイレントインストールにはデバイスオーナーが必要です。</string>
     <string name="installer_engine_dhizuku_desc">デバイスオーナーによるサイレントインストール</string>
+    <string name="setting_install_mode_custom">カスタム</string>
+    <string name="setting_install_mode_custom_sub">カスタムシェルまたは認証コマンド経由でインストール</string>
+    <string name="setting_custom_authorizer_title">カスタム認証機能</string>
+    <string name="setting_custom_authorizer_subtitle">インストールの承認に使用するシェルまたはバイナリを設定します</string>
+    <string name="setting_custom_authorizer_configure">設定</string>
+    <string name="setting_custom_authorizer_presets">クイックプリセット</string>
+    <string name="setting_custom_authorizer_save">保存して適用</string>
+    <string name="setting_custom_authorizer_cmd_label">認証コマンド</string>
+    <string name="setting_custom_authorizer_cmd_hint">例: su -c {command} または su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">{command} プレースホルダーまたは stdin ターミナルモード（例: su, su 1000, rish -c {command}）をサポート。</string>
+    <string name="setting_custom_authorizer_test">テスト</string>
+    <string name="setting_custom_authorizer_test_success">接続成功: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">失敗: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">コマンドを入力してください</string>
+    <string name="setting_custom_authorizer_err_dangerous">危険なコマンドが検出されました (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">「%1$s」は認証ツールではありません (su, ksu, rish, sh などを使用してください)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">%1$s フラグに必要な {command} プレースホルダーがありません</string>
+    <string name="setting_custom_authorizer_reset_default">デフォルトに戻す</string>
+    <string name="installer_mode_custom">カスタム</string>
+    <string name="installer_engine_custom_desc">カスタム認証コマンド経由でインストール</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">탭하여 Dhizuku 권한 부여</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku가 프로필 소유자로 설정되어 있습니다. 자동 설치에는 기기 소유자 권한이 필요합니다.</string>
     <string name="installer_engine_dhizuku_desc">기기 소유자를 통해 자동 설치</string>
+    <string name="setting_install_mode_custom">사용자 지정</string>
+    <string name="setting_install_mode_custom_sub">사용자 지정 셸 또는 인증 명령을 통해 설치</string>
+    <string name="setting_custom_authorizer_title">사용자 지정 인증 도구</string>
+    <string name="setting_custom_authorizer_subtitle">설치를 승인할 사용자 지정 셸 또는 바이너리 구성</string>
+    <string name="setting_custom_authorizer_configure">구성</string>
+    <string name="setting_custom_authorizer_presets">빠른 프리셋</string>
+    <string name="setting_custom_authorizer_save">저장 및 적용</string>
+    <string name="setting_custom_authorizer_cmd_label">인증 명령</string>
+    <string name="setting_custom_authorizer_cmd_hint">예: su -c {command} 또는 su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">{command} 자리표시자 또는 stdin 터미널 모드 지원 (예: su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">테스트</string>
+    <string name="setting_custom_authorizer_test_success">연결됨: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">실패: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">명령어를 비워둘 수 없습니다</string>
+    <string name="setting_custom_authorizer_err_dangerous">위험한 명령어 감지됨 (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\'은(는) 인증 도구가 아닙니다 (su, ksu, rish, sh 등을 사용하세요)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">%1$s 플래그에 필요한 {command} 자리표시자가 없습니다</string>
+    <string name="setting_custom_authorizer_reset_default">기본값으로 초기화</string>
+    <string name="installer_mode_custom">사용자 지정</string>
+    <string name="installer_engine_custom_desc">사용자 지정 인증 명령을 통해 설치</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -847,4 +847,24 @@
     <string name="setting_dhizuku_no_permission">Stuknij, aby przyznać uprawnienia Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku jest ustawiony jako właściciel profilu. Cicha instalacja wymaga uprawnień właściciela urządzenia.</string>
     <string name="installer_engine_dhizuku_desc">Instaluj w tle przez właściciela urządzenia</string>
+    <string name="setting_install_mode_custom">Własny</string>
+    <string name="setting_install_mode_custom_sub">Instaluj przez niestandardową powłokę lub polecenie autoryzatora</string>
+    <string name="setting_custom_authorizer_title">Niestandardowy autoryzator</string>
+    <string name="setting_custom_authorizer_subtitle">Skonfiguruj powłokę lub plik binarny do autoryzacji instalacji</string>
+    <string name="setting_custom_authorizer_configure">Konfiguruj</string>
+    <string name="setting_custom_authorizer_presets">Szybkie szablony</string>
+    <string name="setting_custom_authorizer_save">Zapisz i zastosuj</string>
+    <string name="setting_custom_authorizer_cmd_label">Polecenie autoryzatora</string>
+    <string name="setting_custom_authorizer_cmd_hint">np. su -c {command} lub su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Obsługuje symbol zastępczy {command} lub tryb terminala stdin (np. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Testuj</string>
+    <string name="setting_custom_authorizer_test_success">Połączono: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Niepowodzenie: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Polecenie nie może być puste</string>
+    <string name="setting_custom_authorizer_err_dangerous">Wykryto niebezpieczne polecenie (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' nie jest autoryzatorem (użyj su, ksu, rish, sh itp.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Brakujący symbol zastępczy {command} dla flagi %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Przywróć domyślne</string>
+    <string name="installer_mode_custom">Własny</string>
+    <string name="installer_engine_custom_desc">Instaluj przez niestandardowe polecenie autoryzatora</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Toque para conceder permissão ao Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">O Dhizuku está configurado como Proprietário do perfil. A instalação silenciosa requer o Proprietário do dispositivo.</string>
     <string name="installer_engine_dhizuku_desc">Instalar silenciosamente pelo Proprietário do dispositivo</string>
+    <string name="setting_install_mode_custom">Personalizado</string>
+    <string name="setting_install_mode_custom_sub">Instalar via shell personalizada ou comando autorizador</string>
+    <string name="setting_custom_authorizer_title">Autorizador personalizado</string>
+    <string name="setting_custom_authorizer_subtitle">Configurar shell ou binário personalizado para autorizar instalações</string>
+    <string name="setting_custom_authorizer_configure">Configurar</string>
+    <string name="setting_custom_authorizer_presets">Modelos rápidos</string>
+    <string name="setting_custom_authorizer_save">Salvar e aplicar</string>
+    <string name="setting_custom_authorizer_cmd_label">Comando autorizador</string>
+    <string name="setting_custom_authorizer_cmd_hint">ex: su -c {command} ou su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Suporta marcador {command} ou modo terminal stdin (ex: su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Testar</string>
+    <string name="setting_custom_authorizer_test_success">Conectado: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Falhou: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">O comando não pode estar em branco</string>
+    <string name="setting_custom_authorizer_err_dangerous">Comando perigoso detectado (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' não é um autorizador (use su, ksu, rish, sh, etc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Marcador {command} ausente para o parâmetro %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Restaurar padrão</string>
+    <string name="installer_mode_custom">Personalizado</string>
+    <string name="installer_engine_custom_desc">Instalar via comando autorizador personalizado</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Atinge pentru a acorda permisiunea Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku este setat ca proprietar de profil. Instalarea silențioasă necesită proprietarul dispozitivului.</string>
     <string name="installer_engine_dhizuku_desc">Instalare silențioasă prin proprietarul dispozitivului</string>
+    <string name="setting_install_mode_custom">Personalizat</string>
+    <string name="setting_install_mode_custom_sub">Instalați prin shell personalizat sau comandă de autorizare</string>
+    <string name="setting_custom_authorizer_title">Autorizator personalizat</string>
+    <string name="setting_custom_authorizer_subtitle">Configurați un shell sau binar personalizat pentru autorizarea instalărilor</string>
+    <string name="setting_custom_authorizer_configure">Configurare</string>
+    <string name="setting_custom_authorizer_presets">Presetări rapide</string>
+    <string name="setting_custom_authorizer_save">Salvați și aplicați</string>
+    <string name="setting_custom_authorizer_cmd_label">Comandă de autorizare</string>
+    <string name="setting_custom_authorizer_cmd_hint">ex. su -c {command} sau su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Acceptă substituentul {command} sau modul terminal stdin (ex. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Testare</string>
+    <string name="setting_custom_authorizer_test_success">Conectat: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Eșuat: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Comanda nu poate fi goală</string>
+    <string name="setting_custom_authorizer_err_dangerous">Comandă periculoasă detectată (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' nu este un autorizator (folosiți su, ksu, rish, sh etc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Lipsește substituentul {command} pentru parametrul %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Resetare la valorile implicite</string>
+    <string name="installer_mode_custom">Personalizat</string>
+    <string name="installer_engine_custom_desc">Instalați prin comandă de autorizare personalizată</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Нажмите, чтобы предоставить разрешение Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku настроен как владелец профиля. Для тихой установки требуется владелец устройства.</string>
     <string name="installer_engine_dhizuku_desc">Тихая установка через владельца устройства</string>
+    <string name="setting_install_mode_custom">Пользовательский</string>
+    <string name="setting_install_mode_custom_sub">Установка через кастомную оболочку или команду авторизации</string>
+    <string name="setting_custom_authorizer_title">Пользовательский авторизатор</string>
+    <string name="setting_custom_authorizer_subtitle">Настройка оболочки или бинарного файла для авторизации установки</string>
+    <string name="setting_custom_authorizer_configure">Настроить</string>
+    <string name="setting_custom_authorizer_presets">Быстрые шаблоны</string>
+    <string name="setting_custom_authorizer_save">Сохранить и применить</string>
+    <string name="setting_custom_authorizer_cmd_label">Команда авторизатора</string>
+    <string name="setting_custom_authorizer_cmd_hint">например: su -c {command} или su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Поддерживает заполнитель {command} или терминальный режим stdin (например: su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Проверить</string>
+    <string name="setting_custom_authorizer_test_success">Подключено: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Ошибка: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Команда не может быть пустой</string>
+    <string name="setting_custom_authorizer_err_dangerous">Обнаружена опасная команда (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' не является авторизатором (используйте su, ksu, rish, sh и т.д.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Отсутствует заполнитель {command} для флага %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">По умолчанию</string>
+    <string name="installer_mode_custom">Пользовательский</string>
+    <string name="installer_engine_custom_desc">Установка через пользовательскую команду авторизатора</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Dhizuku izni vermek için dokunun</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku Profil Sahibi olarak ayarlanmış. Sessiz kurulum Cihaz Sahibi gerektirir.</string>
     <string name="installer_engine_dhizuku_desc">Cihaz Sahibi ile sessiz kurulum</string>
+    <string name="setting_install_mode_custom">Özel</string>
+    <string name="setting_install_mode_custom_sub">Özel kabuk veya yetkilendirici komutuyla yükleyin</string>
+    <string name="setting_custom_authorizer_title">Özel Yetkilendirici</string>
+    <string name="setting_custom_authorizer_subtitle">Yüklemeleri yetkilendirmek için özel kabuk veya ikili dosyayı yapılandırın</string>
+    <string name="setting_custom_authorizer_configure">Yapılandır</string>
+    <string name="setting_custom_authorizer_presets">Hızlı Şablonlar</string>
+    <string name="setting_custom_authorizer_save">Kaydet ve Uygula</string>
+    <string name="setting_custom_authorizer_cmd_label">Yetkilendirici komutu</string>
+    <string name="setting_custom_authorizer_cmd_hint">ör. su -c {command} veya su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">{command} yer tutucusunu veya stdin terminal modunu destekler (ör. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Test Et</string>
+    <string name="setting_custom_authorizer_test_success">Bağlandı: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Başarısız: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Komut boş olamaz</string>
+    <string name="setting_custom_authorizer_err_dangerous">Tehlikeli komut algılandı (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' bir yetkilendirici değil (su, ksu, rish, sh vb. kullanın)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">%1$s bayrağı için {command} yer tutucusu eksik</string>
+    <string name="setting_custom_authorizer_reset_default">Varsayılana sıfırla</string>
+    <string name="installer_mode_custom">Özel</string>
+    <string name="installer_engine_custom_desc">Özel yetkilendirici komutuyla yükleyin</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">Торкніться, щоб надати дозвіл Dhizuku</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku налаштовано як власника профілю. Для тихого встановлення потрібен власник пристрою.</string>
     <string name="installer_engine_dhizuku_desc">Тихе встановлення через власника пристрою</string>
+    <string name="setting_install_mode_custom">Користувацький</string>
+    <string name="setting_install_mode_custom_sub">Встановлення через власну оболонку або команду авторизації</string>
+    <string name="setting_custom_authorizer_title">Користувацький авторизатор</string>
+    <string name="setting_custom_authorizer_subtitle">Налаштування оболонки або виконуваного файлу для авторизації встановлення</string>
+    <string name="setting_custom_authorizer_configure">Налаштувати</string>
+    <string name="setting_custom_authorizer_presets">Швидкі шаблони</string>
+    <string name="setting_custom_authorizer_save">Зберегти та застосувати</string>
+    <string name="setting_custom_authorizer_cmd_label">Команда авторизатора</string>
+    <string name="setting_custom_authorizer_cmd_hint">наприклад: su -c {command} або su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Підтримує заповнювач {command} або термінальний режим stdin (наприклад: su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Перевірити</string>
+    <string name="setting_custom_authorizer_test_success">Підключено: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Помилка: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Команда не може бути порожньою</string>
+    <string name="setting_custom_authorizer_err_dangerous">Виявлено небезпечну команду (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' не є авторизатором (використовуйте su, ksu, rish, sh тощо)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Відсутній заповнювач {command} для прапорця %1$s</string>
+    <string name="setting_custom_authorizer_reset_default">Скинути до типового</string>
+    <string name="installer_mode_custom">Користувацький</string>
+    <string name="installer_engine_custom_desc">Встановлення через власну команду авторизатора</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -610,7 +610,15 @@
   <string name="setting_dhizuku_denied">Dhizuku đã từ chối yêu cầu cấp quyền</string>
   <string name="setting_dhizuku_ready">Sẵn sàng — cài im lặng. Lưu ý Dhizuku chỉ hỗ trợ \&quot;Cho phép hạ cấp\&quot;; các tuỳ chọn cài đặt khác chỉ áp dụng cho Shizuku và Root.</string>
   <string name="setting_install_mode_root">Root</string>
+  <string name="setting_install_mode_custom">Tùy chỉnh</string>
   <string name="setting_install_mode_default_sub">Trình cài đặt của Android — sẽ hỏi bạn xác nhận từng ứng dụng</string>
+  <string name="setting_install_mode_custom_sub">Cài đặt qua lệnh shell hoặc authorizer tùy chỉnh</string>
+  <string name="setting_custom_authorizer_cmd_label">Lệnh Authorizer</string>
+  <string name="setting_custom_authorizer_cmd_hint">VD: su -c {command} hoặc su 1000</string>
+  <string name="setting_custom_authorizer_cmd_desc">Hỗ trợ biến {command} hoặc chạy qua terminal stdin (VD: su, su 1000, rish -c {command}).</string>
+  <string name="setting_custom_authorizer_test">Kiểm tra</string>
+  <string name="setting_custom_authorizer_test_success">Kết nối thành công: %1$s</string>
+  <string name="setting_custom_authorizer_test_failed">Thất bại: %1$s</string>
   <string name="setting_show_download_tab_title">Hiển thị Tab Tải xuống</string>
   <string name="setting_show_download_tab_subtitle">Hiển thị tab Tải xuống trên màn hình chính để cài đặt APK từ xa</string>
   <string name="manage_batch_action_force_stop">Buộc dừng</string>
@@ -766,6 +774,8 @@
   <string name="installer_engine_dhizuku_desc">Cài đặt im lặng qua Device Owner</string>
   <string name="installer_engine_root_desc">Cài đặt bằng root (su)</string>
   <string name="installer_engine_root_unsupported">Không khả dụng trên bản dựng này</string>
+  <string name="installer_mode_custom">Tùy chỉnh</string>
+  <string name="installer_engine_custom_desc">Cài đặt qua lệnh authorizer tùy chỉnh</string>
   <string name="backup_split_format_label">Định dạng ứng dụng tách</string>
   <string name="dir_picker_browse_action">Duyệt thư mục</string>
   <string name="dir_picker_use_folder">Dùng thư mục này</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -619,6 +619,11 @@
   <string name="setting_custom_authorizer_test">Kiểm tra</string>
   <string name="setting_custom_authorizer_test_success">Kết nối thành công: %1$s</string>
   <string name="setting_custom_authorizer_test_failed">Thất bại: %1$s</string>
+  <string name="setting_custom_authorizer_err_blank">Lệnh authorizer không được để trống</string>
+  <string name="setting_custom_authorizer_err_dangerous">Phát hiện lệnh nguy hiểm (%1$s)</string>
+  <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' không phải công cụ cấp quyền (hãy dùng su, ksu, rish, sh,...)</string>
+  <string name="setting_custom_authorizer_err_missing_placeholder">Thiếu {command} cho tham số %1$s (ví dụ: su -c {command})</string>
+  <string name="setting_custom_authorizer_reset_default">Khôi phục mặc định</string>
   <string name="setting_show_download_tab_title">Hiển thị Tab Tải xuống</string>
   <string name="setting_show_download_tab_subtitle">Hiển thị tab Tải xuống trên màn hình chính để cài đặt APK từ xa</string>
   <string name="manage_batch_action_force_stop">Buộc dừng</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -613,6 +613,11 @@
   <string name="setting_install_mode_custom">Tùy chỉnh</string>
   <string name="setting_install_mode_default_sub">Trình cài đặt của Android — sẽ hỏi bạn xác nhận từng ứng dụng</string>
   <string name="setting_install_mode_custom_sub">Cài đặt qua lệnh shell hoặc authorizer tùy chỉnh</string>
+  <string name="setting_custom_authorizer_title">Trình cấp quyền tùy chỉnh</string>
+  <string name="setting_custom_authorizer_subtitle">Cấu hình lệnh shell hoặc binary để cấp quyền cài đặt</string>
+  <string name="setting_custom_authorizer_configure">Cấu hình</string>
+  <string name="setting_custom_authorizer_presets">Mẫu có sẵn</string>
+  <string name="setting_custom_authorizer_save">Lưu &amp; Áp dụng</string>
   <string name="setting_custom_authorizer_cmd_label">Lệnh Authorizer</string>
   <string name="setting_custom_authorizer_cmd_hint">VD: su -c {command} hoặc su 1000</string>
   <string name="setting_custom_authorizer_cmd_desc">Hỗ trợ biến {command} hoặc chạy qua terminal stdin (VD: su, su 1000, rish -c {command}).</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -871,4 +871,24 @@
     <string name="setting_dhizuku_no_permission">点击授予 Dhizuku 权限</string>
     <string name="setting_dhizuku_profile_owner_unsupported">Dhizuku 当前被设置为 Profile Owner。静默安装需要 Device Owner 权限。</string>
     <string name="installer_engine_dhizuku_desc">通过设备所有者 (Device Owner) 静默安装</string>
+    <string name="setting_install_mode_custom">自定义</string>
+    <string name="setting_install_mode_custom_sub">通过自定义 Shell 或授权命令安装</string>
+    <string name="setting_custom_authorizer_title">自定义授权工具</string>
+    <string name="setting_custom_authorizer_subtitle">配置用于授权安装的自定义 Shell 或二进制程序</string>
+    <string name="setting_custom_authorizer_configure">配置</string>
+    <string name="setting_custom_authorizer_presets">快速预设</string>
+    <string name="setting_custom_authorizer_save">保存并应用</string>
+    <string name="setting_custom_authorizer_cmd_label">授权命令</string>
+    <string name="setting_custom_authorizer_cmd_hint">例如：su -c {command} 或 su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">支持 {command} 占位符或 stdin 终端模式（例如：su、su 1000、rish -c {command}）。</string>
+    <string name="setting_custom_authorizer_test">测试</string>
+    <string name="setting_custom_authorizer_test_success">已连接：%1$s</string>
+    <string name="setting_custom_authorizer_test_failed">失败：%1$s</string>
+    <string name="setting_custom_authorizer_err_blank">命令不能为空</string>
+    <string name="setting_custom_authorizer_err_dangerous">检测到危险命令 (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">“%1$s” 不是授权工具（请使用 su、ksu、rish、sh 等）</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">%1$s 标记缺少 {command} 占位符</string>
+    <string name="setting_custom_authorizer_reset_default">恢复默认</string>
+    <string name="installer_mode_custom">自定义</string>
+    <string name="installer_engine_custom_desc">通过自定义授权命令安装</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,11 @@
     <string name="setting_install_mode_custom">Custom</string>
     <string name="setting_install_mode_default_sub">Android\'s own installer — it asks you to confirm each app</string>
     <string name="setting_install_mode_custom_sub">Install via custom shell or authorizer command</string>
+    <string name="setting_custom_authorizer_title">Custom Authorizer</string>
+    <string name="setting_custom_authorizer_subtitle">Configure custom shell or binary to authorize installations</string>
+    <string name="setting_custom_authorizer_configure">Configure</string>
+    <string name="setting_custom_authorizer_presets">Quick Presets</string>
+    <string name="setting_custom_authorizer_save">Save &amp; Apply</string>
     <string name="setting_custom_authorizer_cmd_label">Authorizer command</string>
     <string name="setting_custom_authorizer_cmd_hint">e.g. su -c {command} or su 1000</string>
     <string name="setting_custom_authorizer_cmd_desc">Supports {command} placeholder or stdin terminal mode (e.g. su, su 1000, rish -c {command}).</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,7 +384,15 @@
     <string name="setting_dhizuku_denied">Dhizuku denied the permission request</string>
     <string name="setting_dhizuku_ready">Ready — installs run silently. Note Dhizuku only supports \&quot;Allow downgrade\&quot;; the other install options apply to Shizuku and Root only.</string>
     <string name="setting_install_mode_root">Root</string>
+    <string name="setting_install_mode_custom">Custom</string>
     <string name="setting_install_mode_default_sub">Android\'s own installer — it asks you to confirm each app</string>
+    <string name="setting_install_mode_custom_sub">Install via custom shell or authorizer command</string>
+    <string name="setting_custom_authorizer_cmd_label">Authorizer command</string>
+    <string name="setting_custom_authorizer_cmd_hint">e.g. su -c {command} or su 1000</string>
+    <string name="setting_custom_authorizer_cmd_desc">Supports {command} placeholder or stdin terminal mode (e.g. su, su 1000, rish -c {command}).</string>
+    <string name="setting_custom_authorizer_test">Test</string>
+    <string name="setting_custom_authorizer_test_success">Connected: %1$s</string>
+    <string name="setting_custom_authorizer_test_failed">Failed: %1$s</string>
     <string name="setting_shizuku_not_installed">Shizuku not installed</string>
     <string name="setting_shizuku_not_running">Shizuku installed but not running</string>
     <string name="setting_shizuku_unsupported">Shizuku version too old (pre-v11)</string>
@@ -525,6 +533,8 @@
     <string name="installer_engine_root_desc">Install with root (su)</string>
     <string name="installer_engine_root_request">Tap to grant root access</string>
     <string name="installer_engine_root_unsupported">Not available on this build</string>
+    <string name="installer_mode_custom">Custom</string>
+    <string name="installer_engine_custom_desc">Install via custom authorizer command</string>
     <string name="setting_section_install_options">Install options</string>
     <string name="setting_install_options_dhizuku_note">Dhizuku only supports \&quot;Allow downgrade\&quot;. The rest apply when you switch back to Shizuku or Root.</string>
     <string name="install_error_cancelled_title">Installation cancelled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,11 @@
     <string name="setting_custom_authorizer_test">Test</string>
     <string name="setting_custom_authorizer_test_success">Connected: %1$s</string>
     <string name="setting_custom_authorizer_test_failed">Failed: %1$s</string>
+    <string name="setting_custom_authorizer_err_blank">Command cannot be blank</string>
+    <string name="setting_custom_authorizer_err_dangerous">Dangerous command detected (%1$s)</string>
+    <string name="setting_custom_authorizer_err_not_authorizer">\'%1$s\' is not an authorizer (use su, ksu, rish, sh, etc.)</string>
+    <string name="setting_custom_authorizer_err_missing_placeholder">Missing {command} placeholder for %1$s flag</string>
+    <string name="setting_custom_authorizer_reset_default">Reset to default</string>
     <string name="setting_shizuku_not_installed">Shizuku not installed</string>
     <string name="setting_shizuku_not_running">Shizuku installed but not running</string>
     <string name="setting_shizuku_unsupported">Shizuku version too old (pre-v11)</string>

--- a/app/src/test/java/app/pwhs/universalinstaller/util/CustomShellExecutorTest.kt
+++ b/app/src/test/java/app/pwhs/universalinstaller/util/CustomShellExecutorTest.kt
@@ -1,0 +1,48 @@
+package app.pwhs.universalinstaller.util
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CustomShellExecutorTest {
+
+    @Test
+    fun parseCommand_splitsTokensCorrectly() {
+        val tokens1 = CustomShellExecutor.parseCommand("su -c {command}")
+        assertEquals(listOf("su", "-c", "{command}"), tokens1)
+
+        val tokens2 = CustomShellExecutor.parseCommand("su 1000")
+        assertEquals(listOf("su", "1000"), tokens2)
+
+        val tokens3 = CustomShellExecutor.parseCommand("sh /path/to/rish -c {command}")
+        assertEquals(listOf("sh", "/path/to/rish", "-c", "{command}"), tokens3)
+
+        val tokens4 = CustomShellExecutor.parseCommand("sh -c 'echo \"hello world\"'")
+        assertEquals(listOf("sh", "-c", "echo \"hello world\""), tokens4)
+    }
+
+    @Test
+    fun execWithTemplate_placeholderMode_runsCommand() = runBlocking {
+        val result = CustomShellExecutor.execWithTemplate("sh -c {command}", "echo hello_custom")
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.code)
+        assertTrue(result.out.any { it.contains("hello_custom") })
+    }
+
+    @Test
+    fun execWithTemplate_stdinMode_runsCommand() = runBlocking {
+        val result = CustomShellExecutor.execWithTemplate("sh", "echo hello_stdin")
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.code)
+        assertTrue(result.out.any { it.contains("hello_stdin") })
+    }
+
+    @Test
+    fun testCommand_executesSuccessfully() = runBlocking {
+        val testRes = CustomShellExecutor.testCommand("sh -c {command}")
+        assertTrue(testRes.isSuccess)
+        val text = testRes.getOrNull().orEmpty()
+        assertTrue(text.isNotBlank())
+    }
+}

--- a/app/src/test/java/app/pwhs/universalinstaller/util/CustomShellExecutorTest.kt
+++ b/app/src/test/java/app/pwhs/universalinstaller/util/CustomShellExecutorTest.kt
@@ -45,4 +45,53 @@ class CustomShellExecutorTest {
         val text = testRes.getOrNull().orEmpty()
         assertTrue(text.isNotBlank())
     }
+
+    @Test
+    fun validateCommand_detectsDangerousCommands() {
+        val res1 = CustomShellExecutor.validateCommand("rm -rf /")
+        assertTrue(res1 is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.DANGEROUS_COMMAND, (res1 as CustomShellExecutor.ValidationResult.Error).reason)
+
+        val res2 = CustomShellExecutor.validateCommand("su -c 'rm -rf {command}'")
+        assertTrue(res2 is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.DANGEROUS_COMMAND, (res2 as CustomShellExecutor.ValidationResult.Error).reason)
+
+        val res3 = CustomShellExecutor.validateCommand("reboot")
+        assertTrue(res3 is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.DANGEROUS_COMMAND, (res3 as CustomShellExecutor.ValidationResult.Error).reason)
+    }
+
+    @Test
+    fun validateCommand_detectsNonAuthorizerUtilities() {
+        val res1 = CustomShellExecutor.validateCommand("ls -la")
+        assertTrue(res1 is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.NOT_AUTHORIZER_BINARY, (res1 as CustomShellExecutor.ValidationResult.Error).reason)
+
+        val res2 = CustomShellExecutor.validateCommand("cat /etc/hosts")
+        assertTrue(res2 is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.NOT_AUTHORIZER_BINARY, (res2 as CustomShellExecutor.ValidationResult.Error).reason)
+    }
+
+    @Test
+    fun validateCommand_detectsMissingPlaceholder() {
+        val res = CustomShellExecutor.validateCommand("su -c")
+        assertTrue(res is CustomShellExecutor.ValidationResult.Error)
+        assertEquals(CustomShellExecutor.ValidationErrorReason.MISSING_PLACEHOLDER, (res as CustomShellExecutor.ValidationResult.Error).reason)
+    }
+
+    @Test
+    fun validateCommand_acceptsValidAuthorizerCommands() {
+        assertTrue(CustomShellExecutor.validateCommand("su -c {command}") is CustomShellExecutor.ValidationResult.Valid)
+        assertTrue(CustomShellExecutor.validateCommand("su 1000") is CustomShellExecutor.ValidationResult.Valid)
+        assertTrue(CustomShellExecutor.validateCommand("ksu -c {command}") is CustomShellExecutor.ValidationResult.Valid)
+        assertTrue(CustomShellExecutor.validateCommand("rish -c {command}") is CustomShellExecutor.ValidationResult.Valid)
+        assertTrue(CustomShellExecutor.validateCommand("/system/bin/sh -c {command}") is CustomShellExecutor.ValidationResult.Valid)
+    }
+
+    @Test
+    fun execWithTemplate_rejectsDangerousCommands() = runBlocking {
+        val res = CustomShellExecutor.execWithTemplate("rm -rf {command}", "id")
+        assertTrue(!res.isSuccess)
+        assertTrue(res.err.any { it.contains("Unsafe or invalid authorizer command") })
+    }
 }


### PR DESCRIPTION
Closes #101

This PR adds support for **Custom Authorizer / External shell commands** (inspired by InstallerX-Revived) with a modern Material 3 ModalBottomSheet configuration UI, dangerous command validation, and comprehensive multi-language support.

### Highlights:
1. **Custom Shell Executor & Installer Engine**:
   - Implemented `CustomShellExecutor` supporting:
     - **Template Placeholder Mode**: `su -c {command}`, `ksu -c {command}`, `rish -c {command}` with robust quoting and argument tokenization.
     - **Interactive Terminal Mode**: `su`, `su 1000`, `apx run` via stdin stream execution.
     - Built-in `testCommand` health probe directly runnable from settings.
     - Validation guard against non-authorizers (`ls`, `cat`, etc.) and destructive commands (`rm`, `dd`, `wipe`, etc.).
   - Implemented `CustomTargetedInstaller` and `CustomInstallController` handling standard and split APK installations via `pm install-create / write / commit`.
   - Supported custom uninstallation of conflicting packages via `pm uninstall <pkg>`.

2. **Refined Material 3 BottomSheet UI & Presets**:
   - Replaced bulky inline text card in Settings with a sleek, native `ListItem` / `Card` setting row with terminal badge.
   - Introduced `CustomAuthorizerSheet` (ModalBottomSheet):
     - **Quick Presets**: One-tap selection chips for `su -c {command}`, `su`, `rish -c {command}`, `su 1000`, and `ksu -c {command}`.
     - **Terminal Code Editor**: Monospace input with real-time syntax checking, debounced local state, and auto-correct disabled.
     - **Live Test Probe**: Run and view output directly in the sheet (e.g., green success badge with UID/GID, or detailed error badge).
     - **Save & Apply / Cancel**: Safe and deliberate configuration changes.

3. **Install Mode Selector UI Polish**:
   - Upgraded `InstallModeSelector` and profile backend selector from `SingleChoiceSegmentedButtonRow` to responsive `FlowRow` + `FilterChip` with distinct icons (Default, Shizuku, Dhizuku, Root, Custom).
   - Resolves text clipping and overflow when all 5 installation backends are available.

4. **Full 18-Locale Localization (i18n)**:
   - Extracted and translated all 20 new resource keys across **all 18 supported languages** (`ar`, `de`, `el`, `es`, `fr`, `hi`, `in`, `it`, `ja`, `ko`, `pl`, `pt-rBR`, `ro`, `ru`, `tr`, `uk`, `vi`, `zh`) with 0 missing strings.

5. **Testing & Verification**:
   - Comprehensive unit tests in `CustomShellExecutorTest`.
   - Verified on physical Samsung Note 20 Ultra (`R3CN803JCPM`).
   - Clean `./gradlew assembleDebug` build.